### PR TITLE
Add check-modules task (via plugin) to deploy chain

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -4,6 +4,7 @@ grunt.loadNpmTasks( "grunt-clean" );
 grunt.loadNpmTasks( "grunt-html" );
 grunt.loadNpmTasks( "grunt-wordpress" );
 grunt.loadNpmTasks( "grunt-jquery-content" );
+grunt.loadNpmTasks( "grunt-check-modules" );
 
 grunt.initConfig({
 	clean: {
@@ -247,6 +248,6 @@ grunt.registerTask( "create-quickdownload", function() {
 
 grunt.registerTask( "default", "lint" );
 grunt.registerTask( "build", "build-pages build-resources build-download build-demos copy-taxonomies" );
-grunt.registerTask( "build-wordpress", "clean lint build" );
+grunt.registerTask( "build-wordpress", "check-modules clean lint build" );
 
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"grunt-html": "0.1.1",
 		"grunt-wordpress": "1.0.3",
 		"grunt-jquery-content": "0.5.7",
+		"grunt-check-modules": "0.1.0",
 		"download.jqueryui.com": "1.9.1",
 		"jsdom": "0.2.x"
 	},


### PR DESCRIPTION
The plan was to add the task to grunt-jquery-content, for that to bubble it up everywhere else, but as far as I can tell, loading grunt plugins from a grunt plugin doesn't work. So we need to add it to each content repo, like this.

Repo for the plugin: https://github.com/jzaefferer/grunt-check-modules

Once I get an OK for this change, I can add it everywhere else as well.
