### PR TITLE
Adding links to upgrade guides / changelogs / all downloads in the devel...

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -53,6 +53,12 @@
 		</li>
 		<li><a href="http://wiki.jqueryui.com/">Development Planning Wiki</a></li>
 		<li><a href="http://wiki.jqueryui.com/Roadmap/">Roadmap</a></li>
+		<li><a href="/download/all/">Previous Releases</a>
+			<ul>
+				<li><a href="/changelog/">Changelogs</a></li>
+				<li><a href="/upgrade-guide/">Upgrade Guides</a></li>
+			</ul>
+		</li>
 	</ul>
 </div>
 


### PR DESCRIPTION
...oper links box on the home page. Fixes: #45 - Links to upgrade guide

This is the best place I could come up with to link to the upgrade guide / changelogs. The only other potential places would be new sections on the development or support pages. I'm open to ideas.

Thoughts? cc @jzaefferer
