### PR TITLE
Grunt: Change db path from `release` to `jquery-ui`

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -117,7 +117,6 @@ grunt.registerTask( "build-demos", function() {
 		versions = grunt.file.readJSON( downloadModulePath + "/config.json" ),
 		repoDir = downloadModulePath + "/jquery-ui/" + versions.jqueryUi.stable.version,
 		demosDir = repoDir + "/demos",
-		distDir = repoDir + "/dist",
 		targetDir = grunt.config( "wordpress.dir" ) + "/resources/demos",
 		highlightDir = targetDir + "-highlight",
 		demoList = {},


### PR DESCRIPTION
Required for https://github.com/jquery/download.jqueryui.com/pull/146
