### PR TITLE
Upgrade Guide: Minor fixes for 1.11.

### DIFF
--- a/page/upgrade-guide/1.11.md
+++ b/page/upgrade-guide/1.11.md
@@ -125,14 +125,14 @@ This should be a pure bug fix, though if you use the dialog widget along with ot
 
 ### Removed `offset` option; use `my` or `at`
 
-([#6982](http://bugs.jqueryui.com/ticket/6982)) The `offset` option has been removed in favor of providing offset information in `my` or `at`. See [the 1.9 deprecation notice](http://jqueryui.com/upgrade-guide/1.9/#deprecated-offset-option-merged-into-my-and-at) for full details.
+[(#6982)](http://bugs.jqueryui.com/ticket/6982) The `offset` option has been removed in favor of providing offset information in `my` or `at`. See [the 1.9 deprecation notice](http://jqueryui.com/upgrade-guide/1.9/#deprecated-offset-option-merged-into-my-and-at) for full details.
 
 
 ## Menu
 
 ### Added `items` option for better definition of menu items in non parent-child structures
 
-[(31e705a)](https://github.com/jquery/jquery-ui/commit/31e705ab324ec830062eee173a112551f7c919ea) A new [`items` option]((http://api.jqueryui.com/menu/#option-items)) was added to the menu widget. The option allows you to use other markup then the default, such as menu items that aren't immediate children of the menu container parent.
+[(31e705a)](https://github.com/jquery/jquery-ui/commit/31e705ab324ec830062eee173a112551f7c919ea) A new [`items` option](http://api.jqueryui.com/menu/#option-items) was added to the menu widget. The option allows you to use markup other than the default, such as menu items that aren't immediate children of the menu container parent.
 
 ### Remove the requirement to use anchors in menu items
 
@@ -217,7 +217,7 @@ The same constructor functions are also returned when you use the jQuery UI widg
 
 ### Added `instance()` method on the bridge to return widget instance
 
-[(#9030)](http://bugs.jqueryui.com/ticket/9030) A new `instance()` method is now available on the plugin bridge. The method provides access to the widget's instance without going through `$.data()`.
+[(#9030)](http://bugs.jqueryui.com/ticket/9030) A new `instance()` method is now available on the plugin bridge. The method provides access to the widget's instance without going through `.data()`.
 
 Old:
 


### PR DESCRIPTION
- Fixes broken markdown link.
- Fixes typo ("then" -> "than").
- Inaccurate reference `$.data()` replaced with correct `.data()`.
- Parentheses surrounding issue reference moved inside the link.