### PR TITLE
Typo fixes

### DIFF
--- a/page/about.md
+++ b/page/about.md
@@ -8,7 +8,7 @@ jQuery UI is a curated set of user interface interactions, effects, widgets, and
 
 ### Collaborative design process
 
-The process for designing and planning the future of the jQuery UI library should be open, transparent and in the hands of the community. We welcome input from anyone interested in engaging with the team, from hard-core developers to visual and interaction designers, accessiblity experts, product managers, business people, end users and more.
+The process for designing and planning the future of the jQuery UI library should be open, transparent and in the hands of the community. We welcome input from anyone interested in engaging with the team, from hard-core developers to visual and interaction designers, accessibility experts, product managers, business people, end users and more.
 
 ### Flexible styling and themes
 

--- a/page/upgrade-guide/1.10.md
+++ b/page/upgrade-guide/1.10.md
@@ -445,7 +445,7 @@ See [the 1.9 deprecation notice](http://jqueryui.com/upgrade-guide/1.9/#deprecat
 The `add` and `remove` methods have been removed in favor of `refresh`.
 See [the 1.9 deprecation notice](http://jqueryui.com/upgrade-guide/1.9/#deprecated-add-and-remove-methods-and-events-use-refresh-method) for full details.
 
-### Removed `idPrefix`, `tabTemplate`, and `panelTemplate` options; use `refresh` mehod
+### Removed `idPrefix`, `tabTemplate`, and `panelTemplate` options; use `refresh` method
 
 ([#7157](http://bugs.jqueryui.com/ticket/7157))
 The `idPrefix`, `tabTemplate`, and `panelTemplate` options have been removed in favor of the `refresh` method.

--- a/page/upgrade-guide/1.7.md
+++ b/page/upgrade-guide/1.7.md
@@ -16,7 +16,7 @@ be removed in next release).
 * Removed `selectedClass` for consistency reasons to the CSS Framework.
 * Added `resize()` method.
 * Added `changestart` callback that is triggered before the animation starts.
-* Removed deprecated seperate jQuery method `.activate()` (use
+* Removed deprecated separate jQuery method `.activate()` (use
 `accordion( "activate" )` instead).
 * Improved default for `header` option, removing the need to specify the option
 in 99% of all accordions.
@@ -140,7 +140,7 @@ also serialize connected lists.
   * `stop` (and all other events that are fired on end (`receive`, `update`,
   `remove`, `deactivate`)) is triggered after everything else has been
   normalized (placeholder and helper removed, position restored).
-  * For old behaviour (for example to be able to check something on the
+  * For old behavior (for example to be able to check something on the
   placeholder at end), introduced new `beforeStop` callback.
 * If a `key` option is specified to `sortable( "serialize" )`, brackets are no
 longer automatically added to it.
@@ -212,7 +212,7 @@ to be removed in next release).
 without active tab, instead use `-1`.
 * Removed ability to change class names via options.
 * Added `abort()` method to terminate running ajax tab requests and animations.
-* `cookie` option accepts addional `name` property.
+* `cookie` option accepts additional `name` property.
 * States for hover and focus (`.ui-state-hover`, `.ui-state-focus`) added.
 * Default value for `spinner` option changed to `"<em>Loading…</em>"` (before
 `em` was added internally).

--- a/page/upgrade-guide/1.8.4.md
+++ b/page/upgrade-guide/1.8.4.md
@@ -179,7 +179,7 @@ from how they're ordered in the object. However, when tabbing through the dialog
 the OK button would gain focus before the Cancel button.
 
 In 1.8.4, this will result in the OK button being displayed on the left and the
-Cancel button being dispalyed on the right. The buttons will still be tabbed
+Cancel button being displayed on the right. The buttons will still be tabbed
 through in the same order, following the tab order users would expect based on
 the visual layout.
 

--- a/page/upgrade-guide/1.8.6.md
+++ b/page/upgrade-guide/1.8.6.md
@@ -50,7 +50,7 @@ release. However, we will go back to throwing errors in the next major release.
 
 ## Autocomplete
 
-### Allow default behaviour on enter when menu is open but inactive
+### Allow default behavior on enter when menu is open but inactive
 
 ([#6038](http://bugs.jqueryui.com/ticket/6038))
 ([#6055](http://bugs.jqueryui.com/ticket/6055))


### PR DESCRIPTION
/page/about.md
    accessiblity => accessibility

/page/upgrade-guide/1.10.md
    mehod => method

/page/upgrade-guide/1.7.md
    seperate => separate
    behaviour => behavior (American spelling per the Style Guide)
    addional => additional

/page/upgrade-guide/1.8.4.md
    dispalyed => displayed

/page/upgrade-guide/1.8.6.md
    behaviour => behavior (American spelling per the Style Guide)