### PR TITLE
1.12 Upgrade Guide

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,14 +122,17 @@ grunt.registerTask( "build-demos", function() {
 		}
 
 		var content, $,
-			dest = targetDir + "/" + subdir + "/" + filename,
+			destDir = targetDir + "/" + subdir + "/",
+			dest = destDir + filename,
 			highlightDest = highlightDir + "/" + subdir + "/" + filename;
 
 		if ( /html$/.test( filename ) ) {
 			content = replaceResources( grunt.file.read( abspath ) );
 
+			$ = cheerio.load( content );
+			content = deAmd( $, destDir );
+
 			if ( !( /(\/)/.test( subdir ) ) ) {
-				$ = cheerio.load( content );
 				if ( !demoList[ subdir ] ) {
 					demoList[ subdir ] = [];
 				}
@@ -148,6 +151,7 @@ grunt.registerTask( "build-demos", function() {
 				$( "code" ).text( content );
 				grunt.file.write( highlightDest, jqueryContent.syntaxHighlight( $.html() ) );
 			} else {
+				content = $.html();
 				grunt.file.write( dest, content );
 			}
 		} else {
@@ -162,31 +166,45 @@ grunt.registerTask( "build-demos", function() {
 	// Create list of all demos
 	grunt.file.write( targetDir + "/demo-list.json", JSON.stringify( demoList, null, "\t" ) );
 
-	// Copy externals into /resources/demos/external
-	grunt.file.expand( { filter: "isFile" }, externalDir + "/**" ).forEach(function( filename ) {
-		grunt.file.copy( filename, targetDir + "/external/" + filename.replace( externalDir, "" ) );
-	});
+	function deAmd( $, destDir ) {
+		var i18n, globalize,
+			bootstrap = $( "script[src='../bootstrap.js']" ),
+			require = $( "script[src='../../external/requirejs/require.js']" ),
+			extra = bootstrap.attr( "data-modules" );
+
+		// Replace the src on the first tag with core
+		require
+			.replaceWith(
+				"<script src='https://code.jquery.com/jquery-" + jqueryCore + ".js'></script>" +
++				"\n\t<script src=\"https://code.jquery.com/ui/" +
++				pkg.version + "/jquery-ui.js\"></script>" );
+
+		if ( extra ) {
+			i18n = extra.match( /\S+/g ).filter( function( value ) {
+				return /i18n/.test( value );
+			} );
+			external = extra.match( /\S+/g ).filter( function( value ) {
+				return /external/.test( value );
+			} );
+			if ( i18n.length ) {
+				i18n.forEach( function( file ) {
+					grunt.file.copy( repoDir + "/ui/" + file + ".js", destDir + file + ".js" );
+					bootstrap.before( "<script src=\"" + file + ".js\"></script>\n\t" );
+				} );
+			}
+			if ( external.length ) {
+				external.forEach( function( file ) {
+					grunt.file.copy( repoDir + "/" + file + ".js", targetDir + "/" + file + ".js" );
+					bootstrap.before( "<script src=\"/resources/demos/" + file + ".js\"></script>\n\t" );
+				} );
+			}
+		}
+
+		bootstrap
+			.replaceWith( "<script>\n\t$( function() {" + bootstrap.html() + "} );\n\t</script>" );
+	}
 
 	function replaceResources( source ) {
-		// ../../jquery-x.y.z.js -> CDN
-		source = source.replace(
-			/<script src="\.\.\/\.\.\/external\/jquery\/jquery\.js">/,
-			"<script src=\"//code.jquery.com/jquery-" + jqueryCore + ".js\">" );
-
-		// ../../ui/* -> CDN
-		// Only the first script is replaced, all subsequent scripts are dropped,
-		// including the full line
-		source = source.replace(
-			/<script src="\.\.\/\.\.\/ui\/[^>]+>/,
-			"<script src=\"//code.jquery.com/ui/" + pkg.version + "/jquery-ui.js\">" );
-		source = source.replace(
-			/^.*<script src="\.\.\/\.\.\/ui\/[^>]+><\/script>\n/gm,
-			"" );
-
-		// ../../external/* -> /resources/demos/external/*
-		source = source.replace(
-			/<script src="\.\.\/\.\.\/external\//g,
-			"<script src=\"/resources/demos/external/" );
 
 		// ../../ui/themes/* -> CDN
 		source = source.replace(

--- a/page/upgrade-guide.md
+++ b/page/upgrade-guide.md
@@ -3,6 +3,9 @@
 	"noHeadingLinks": true
 }</script>
 
+## [1.12 Upgrade Guide](/upgrade-guide/1.12/)
+Released on October ??, 2015
+
 ## [1.11 Upgrade Guide](/upgrade-guide/1.11/)
 Released on June 26, 2014
 

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -39,6 +39,8 @@ brand new checkboxradio widget...
 
 ## Dialog
 
+### Deprecated `dialogClass` in favor of `classes.ui-dialog`
+
 The `dialogClass` option is now deprecated. Use the new `classes` option with the `"ui-dialog"` property instead.
 
 Old:
@@ -59,12 +61,33 @@ $( ".content" ).dialog( {
 
 ## Droppable
 
-The `activeClass` and `hoverClass` options are now deprecated. Use the new `classes` option with the `"ui-droppable-active"` and `"ui-droppable-hover"` properties instead.
+### Deprecated `activeClass` in favor of `classes.ui-droppable-active`
+
+The `activeClass` option is now deprecated. Use the new `classes` option with the `"ui-droppable-active"` property instead.
 
 Old:
 ```js
 $( ".target" ).droppable( {
-	activeClass: "drop-target",
+	activeClass: "drop-target"
+} );
+```
+
+New:
+```js
+$( ".target" ).droppable( {
+	classes: {
+		"ui-droppable-active": "drop-target"
+	}
+} );
+```
+
+### Deprecated `hoverClass` in favor of `classes.ui-droppable-hover`
+
+The `hoverClass` option is now deprecated. Use the new `classes` option with the `"ui-droppable-hover"` property instead.
+
+Old:
+```js
+$( ".target" ).droppable( {
 	hoverClass: "drop-hover"
 } );
 ```
@@ -73,13 +96,14 @@ New:
 ```js
 $( ".target" ).droppable( {
 	classes: {
-		"ui-droppable-active": "drop-target",
 		"ui-droppable-hover": "drop-hover"
 	}
 } );
 ```
 
 ## Menu
+
+### Require wrappers for each menu item
 
 [(#10162)](http://bugs.jqueryui.com/ticket/10162) To resolve [several styling issues](http://bugs.jqueryui.com/ticket/10162), the menu widget now requires each menu item to be wrapped with a DOM element. The example below uses `<div>` elements for wrappers, but you can use any block-level element.
 
@@ -111,6 +135,8 @@ The autocomplete and selectmenu widgets, which both use menu internally, were bo
 
 ## Tooltip
 
+### Deprecated `tooltipClass` in favor of `classes.ui-tooltip`
+
 The `tooltipClass` option is now deprecated. Use the new `classes` option with the `"ui-tooltip"` property instead.
 
 Old:
@@ -126,5 +152,25 @@ $( ".content" ).tooltip( {
 	classes: {
 		"ui-tooltip": "warning"
 	}
+} );
+```
+
+## Effects
+
+### Make transfer effect a jQuery plugin method
+
+The transfer effect was available through the extended `.show()`, `.hide()` and `.toggle()` methods, which was a side-effect of exposing it as an effect, but made no semantic sense. The effect is now available exclusively through the `.transfer()` method.
+
+Old:
+```js
+$( ".from" ).effect( "transfer", {
+	to: $( ".target" )
+} );
+```
+
+New:
+```js
+$( ".from" ).transfer( {
+	to: $( ".target" )
 } );
 ```

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -9,7 +9,7 @@ This guide will assist in upgrading from jQuery UI 1.11.x to jQuery UI 1.12.x. A
 
 ## General changes
 
-...
+Independent of changes to specific component, this release removes support for IE7, modernizes the theming and improves support for AMD.
 
 ### Removed IE7 workarounds
 
@@ -17,17 +17,75 @@ This guide will assist in upgrading from jQuery UI 1.11.x to jQuery UI 1.12.x. A
 
 ### Font size changes
 
-...
+jQuery UI themes used to be built around a `body` font-size of 62.5%. This rather small font-size default is now gone, assuming instead the default font-size of browsers.
+
+### New default theme
+
+jQuery UI used to ship with a default theme called Smoothness. This theme is still available through ThemeRoller, but has been replaced by a new default theme called Base. This new theme has been modernized to get rid of background gradients, reduce rounded corners and use some colors outside of the greyscale range. In other words, it looks much better.
+
+### AMD support
+
+All source files in jQuery UI now contain UMD wrappers, making it easier to load these files through AMD loaders like requirejs. You no longer no to provide a `shim` property or equivalent for loading jQuery UI components.
+
+## Button
+
+REWRITE WARNING PLACEHOLDER
+
+button is still button, but doesn't support checkbox/radio anymore, only a single icon (with more flexible positioning), text option renamed to showLabel.
+
+buttonset is now controlgroup, supports more than just button
+
+brand new checkboxradio widget...
+
+## Dialog
+
+The `dialogClass` option is now deprecated. Use the new `classes` option with the `"ui-dialog"` property instead.
+
+Old:
+```js
+$( ".content" ).dialog( {
+	dialogClass: "payment-dialog"
+} );
+```
+
+New:
+```js
+$( ".content" ).dialog( {
+	classes: {
+		"ui-dialog": "payment-dialog"
+	}
+} );
+```
+
+## Droppable
+
+The `activeClass` and `hoverClass` options are now deprecated. Use the new `classes` option with the `"ui-droppable-active"` and `"ui-droppable-hover"` properties instead.
+
+Old:
+```js
+$( ".target" ).droppable( {
+	activeClass: "drop-target",
+	hoverClass: "drop-hover"
+} );
+```
+
+New:
+```js
+$( ".target" ).droppable( {
+	classes: {
+		"ui-droppable-active": "drop-target",
+		"ui-droppable-hover": "drop-hover"
+	}
+} );
+```
 
 ## Menu
-
-### Menu items now require wrappers
 
 [(#10162)](http://bugs.jqueryui.com/ticket/10162) To resolve [several styling issues](http://bugs.jqueryui.com/ticket/10162), the menu widget now requires each menu item to be wrapped with a DOM element. The example below uses `<div>` elements for wrappers, but you can use any block-level element.
 
 Old:
 
-```
+```html
 <ul id="menu">
 	<li>One</li>
 	<li>Two</li>
@@ -36,7 +94,7 @@ Old:
 
 New:
 
-```
+```html
 <ul id="menu">
 	<li>
 		<div>One</div>
@@ -49,3 +107,24 @@ New:
 
 The autocomplete and selectmenu widgets, which both use menu internally, were both updated to include wrappers.
 
+<p clas="warning">This is a breaking change. If you use menu directly in your project, you need to update its markup to include the wrappers. Otherwise you'll end up with a menu that looks wrong and can't be interacted with.</p>
+
+## Tooltip
+
+The `tooltipClass` option is now deprecated. Use the new `classes` option with the `"ui-tooltip"` property instead.
+
+Old:
+```js
+$( ".content" ).tooltip( {
+	tooltipClass: "warning"
+} );
+```
+
+New:
+```js
+$( ".content" ).tooltip( {
+	classes: {
+		"ui-tooltip": "warning"
+	}
+} );
+```

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -9,7 +9,7 @@ This guide will assist in upgrading from jQuery UI 1.11.x to jQuery UI 1.12.x. A
 
 ## General changes
 
-Independent of changes to specific component, this release removes support for IE7, modernizes the theming and improves support for AMD.
+Independent of changes to specific component, this release removes support for IE7, modernizes the theming, including the default font-size, and improves support for AMD. The minimal jQuery version supported is now 1.7.x.
 
 ### Removed IE7 workarounds
 
@@ -17,15 +17,33 @@ Independent of changes to specific component, this release removes support for I
 
 ### Font size changes
 
-jQuery UI themes used to be built around a `body` font-size of 62.5%. This rather small font-size default is now gone, assuming instead the default font-size of browsers.
+[(#10131)](http://bugs.jqueryui.com/ticket/10131) jQuery UI themes used to be built around a `body` font-size of 62.5%, while widgets compensated for that with font-size of 1.1em. This rather small font-size default is now gone, assuming instead the default font-size of browsers.
 
 ### New default theme
 
-jQuery UI used to ship with a default theme called Smoothness. This theme is still available through ThemeRoller, but has been replaced by a new default theme called Base. This new theme has been modernized to get rid of background gradients, reduce rounded corners and use some colors outside of the greyscale range. In other words, it looks much better.
+[(#10617)](http://bugs.jqueryui.com/ticket/10617) jQuery UI used to ship with a default theme called Smoothness. This theme is still available through ThemeRoller, but has been replaced by a new default theme called Base. This new theme has been modernized to get rid of background gradients, reduce rounded corners and use some colors outside of the greyscale range. In other words, it looks much better.
 
-### AMD support
+### Dropped support for jQuery 1.6
 
-All source files in jQuery UI now contain UMD wrappers, making it easier to load these files through AMD loaders like requirejs. You no longer no to provide a `shim` property or equivalent for loading jQuery UI components.
+[(#10723)](http://bugs.jqueryui.com/ticket/10723) jQuery UI no longer supports jQuery 1.6. The minimal supported version is now 1.7.0.
+
+## Core
+
+### Removed .focus( delay )
+
+[(#9649)](http://bugs.jqueryui.com/ticket/9649) The deprecated `.focus( delay )` method override has been removed. jQuery UI was using this only in our dialog widget, where we've replaced the delayed focus call with a timeout.
+
+### Removed .zIndex()
+
+[(#9156)](http://bugs.jqueryui.com/ticket/9156) The deprecated `.zIndex()` method has been removed, in favor of the new `.ui-front` / `appendTo` logic used by all widgets that display an element on top of the page, like dialog and autocomplete.
+
+This method was used by dialog, but because the dialog now has an [`appendTo` option](http://api.jqueryui.com/dialog/#option-appendTo), this plugin method is no longer necessary. If you are using `.zIndex()`, or building a widget that must stack, check out our [guide to create stacking elements with a `ui-front` class name and `appendTo` option](http://api.jqueryui.com/theming/stacking-elements/).
+
+## Mouse
+
+### Deprecate distance and delay options
+
+[(#10615)](http://bugs.jqueryui.com/ticket/10615) Interactions should be instantaneous. These settings are typically used to prevent accidental drags, but a proper fix for that is to improve the UX, e.g., using handles to avoid accidental drags.
 
 ## Button
 
@@ -41,7 +59,7 @@ brand new checkboxradio widget...
 
 ### Deprecated `dialogClass` in favor of `classes.ui-dialog`
 
-The `dialogClass` option is now deprecated. Use the new `classes` option with the `"ui-dialog"` property instead.
+[(#12161)](http://bugs.jqueryui.com/ticket/12161) The `dialogClass` option is now deprecated. Use the new `classes` option with the `"ui-dialog"` property instead.
 
 Old:
 ```js
@@ -63,7 +81,7 @@ $( ".content" ).dialog( {
 
 ### Deprecated `activeClass` in favor of `classes.ui-droppable-active`
 
-The `activeClass` option is now deprecated. Use the new `classes` option with the `"ui-droppable-active"` property instead.
+[(#12162)](http://bugs.jqueryui.com/ticket/12162) The `activeClass` option is now deprecated. Use the new `classes` option with the `"ui-droppable-active"` property instead.
 
 Old:
 ```js
@@ -83,7 +101,7 @@ $( ".target" ).droppable( {
 
 ### Deprecated `hoverClass` in favor of `classes.ui-droppable-hover`
 
-The `hoverClass` option is now deprecated. Use the new `classes` option with the `"ui-droppable-hover"` property instead.
+[(#12162)](http://bugs.jqueryui.com/ticket/12162) The `hoverClass` option is now deprecated. Use the new `classes` option with the `"ui-droppable-hover"` property instead.
 
 Old:
 ```js
@@ -100,6 +118,10 @@ $( ".target" ).droppable( {
 	}
 } );
 ```
+
+### Removed `$.ui.intersect()`
+
+[(#10534)](http://bugs.jqueryui.com/ticket/10534) Droppable used to define `$.ui.intersect()` which was only used in droppable itself and is not documented anywhere. We moved this method inside the closure, effectively removing it.
 
 ## Menu
 
@@ -133,11 +155,33 @@ The autocomplete and selectmenu widgets, which both use menu internally, were bo
 
 <p clas="warning">This is a breaking change. If you use menu directly in your project, you need to update its markup to include the wrappers. Otherwise you'll end up with a menu that looks wrong and can't be interacted with.</p>
 
+### Use consistent styling for focused and active items
+
+[(#10692)](http://bugs.jqueryui.com/ticket/10692) We used to style active parent menu items with "ui-state-active", while everything else got "ui-state-focus" (or hover, which we style the same as focus). When a menu item in a submenu has focus, the parent menu item gets "ui-state-active", which is inconsistent and confusing. We've now switched to using only the "ui-state-active" class.
+
+## Selectmenu
+
+### Added `_renderButtonItem()` method
+
+[(#10142)](http://bugs.jqueryui.com/ticket/10142) The [new extension method `._renderButtonItem()`](http://api.jqueryui.com/selectmenu/#method-_renderButtonItem) makes customizations of how the selected item is rendered a lot easier.
+
+### Support `width: false` and default to 14em
+
+[(#11198)](http://bugs.jqueryui.com/ticket/11198) `width: null` still matches the width of the original element. `width: false` prevents an inline style from being set for the width. This makes it easy to set the width via a stylesheet and allows the use of any unit for setting the width, such as the new default of 14em.
+
+
+
+## Tabs
+
+### Deprecated `ui-tab` class, replaced with `ui-tabs-tab`
+
+[(#12061)](http://bugs.jqueryui.com/ticket/12061) The tabs widget now adds the `ui-tabs-tab` class instead of the inconsistently named `ui-tab` to each tab element.
+
 ## Tooltip
 
 ### Deprecated `tooltipClass` in favor of `classes.ui-tooltip`
 
-The `tooltipClass` option is now deprecated. Use the new `classes` option with the `"ui-tooltip"` property instead.
+[(#12167)](http://bugs.jqueryui.com/ticket/12167) The `tooltipClass` option is now deprecated. Use the new `classes` option with the `"ui-tooltip"` property instead.
 
 Old:
 ```js
@@ -151,6 +195,26 @@ New:
 $( ".content" ).tooltip( {
 	classes: {
 		"ui-tooltip": "warning"
+	}
+} );
+```
+
+### Allow DOM elements and jQuery objects as content
+
+[(#9278)](http://bugs.jqueryui.com/ticket/9278) Tooltip now accepts HTMLElement and jQuery objects for the content option.
+
+## Widget
+
+### Ability to customize style-related CSS classes
+
+[(#7053)](http://bugs.jqueryui.com/ticket/7053) jQuery UI used to hardcode classes like `.ui-corner-all` in widgets. We removed the hardcoding and added the ability to customize the style-related classes based on the functional classes. For the dialog, droppable and tooltip widgets, we replaced options that were doing just that.
+
+Here's an example using dialog:
+```js
+$( "#dialog" ).dialog( {
+	classes: {
+		"ui-dialog": "ui-corner-top awesome-fade-class",
+		"ui-dialog-titlebar": null
 	}
 } );
 ```

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -39,6 +39,10 @@ Independent of changes to specific component, this release removes support for I
 
 This method was used by dialog, but because the dialog now has an [`appendTo` option](http://api.jqueryui.com/dialog/#option-appendTo), this plugin method is no longer necessary. If you are using `.zIndex()`, or building a widget that must stack, check out our [guide to create stacking elements with a `ui-front` class name and `appendTo` option](http://api.jqueryui.com/theming/stacking-elements/).
 
+### Added .labels()
+
+[(#12475)](http://bugs.jqueryui.com/ticket/12475) This release introduces a new jQuery plugin method. `.labels()` finds all label elements associated with the first selected element.
+
 ## Mouse
 
 ### Deprecate distance and delay options

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -37,7 +37,7 @@ Independent of changes to specific component, this release removes support for I
 
 ### Explicit CSS dependencies
 
-In jQuery UI 1.11 we added support for AMD dependency management, but this applied only for JS files. CSS files still had to be managed manually (though download builder helps). In 1.12 all JS components now explicitly list their non-transient CSS dependencies, through structured source comments. For example, `widgets/autocomplete.js` has these comments:
+In jQuery UI 1.11 we added support for AMD dependency management, but this applied only for JS files. CSS files still had to be managed manually (though download builder helps). In 1.12 all JS components now explicitly list their direct CSS dependencies, through structured source comments. For example, `widgets/autocomplete.js` has these comments:
 ```js
 //>>css.structure: ../../themes/base/core.css
 //>>css.structure: ../../themes/base/autocomplete.css

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -51,13 +51,122 @@ This method was used by dialog, but because the dialog now has an [`appendTo` op
 
 ## Button
 
-REWRITE WARNING PLACEHOLDER
+The button widget underwent a rewrite in this release. Most notably, support for inputs of type checkbox and radio has been extracted into a standalone [checkboxradio widget](http://api.jqueryui.com/checkboxradio/), and support for groups of buttons has been extracted into a more generic [controlgroup widget](http://api.jqueryui.com/controlgroup/). The remaining button widget also underwent some changes, simplifiying markup and options.
 
-button is still button, but doesn't support checkbox/radio anymore, only a single icon (with more flexible positioning), text option renamed to showLabel.
+### Deprecated `icons` options in favor of `icon` and `iconPosition`
 
-buttonset is now controlgroup, supports more than just button
+The button widget used to have an `icons` option that supported `primary` and `secondary` properties, allowing up to two icons at once. This has been replaced by the `icon` option, which only allows a single icon, and the `iconPosition` option, which controls the placement of that one icon.
 
-brand new checkboxradio widget...
+The equivalent of the old `primary` icons property is `iconPosition: "beginning"`, while the equivalent of the old `secondary` icons property is `iconPosition: "end"`. The new button also supports "top" and "bottom" for `iconPosition`, allowing the icon to be displayed above or below the button text.
+
+To replace a primary icon:
+
+Old:
+```js
+$( "button" ).button( {
+	icons: {
+		primary: "ui-icon-lock"
+	}
+} );
+```
+
+New:
+```js
+$( "button" ).button( {
+	icon: "ui-icon-lock"
+} );
+```
+
+Replacing a secondary icon also requires the `iconPosition` option:
+
+Old:
+```js
+$( "button" ).button( {
+	icons: {
+		secondary: "ui-icon-gear"
+	}
+} );
+```
+
+New:
+```js
+$( "button" ).button( {
+	icon: "ui-icon-gear",
+	iconPosition: "end"
+} );
+```
+
+### Deprecated `text` option in favor of `showLabel`
+
+This option was renamed for clarity, otherwise it hasn't changed.
+
+Old:
+```js
+$( "button" ).button( {
+	text: false,
+	// still can't hide text without an icon
+	icons: {
+		primary: "ui-icon-gear"
+	}
+} );
+```
+
+New:
+```js
+$( "button" ).button( {
+	showLabel: false,
+	icon: "ui-icon-gear"
+} );
+```
+
+### Deprecated support for `input[type=checkbox]` and `input[type=radio]`, in favor of the new checkboxradio widget
+
+If you're using the button widget with one of these input types, replace it with the new [checkboxradio widget](http://api.jqueryui.com/checkboxradio/):
+
+Old:
+```js
+$( "input[type=checkbox]" ).button();
+```
+
+New:
+```js
+$( "input[type=checkbox]" ).checkboxradio();
+```
+
+Both old and new `button` and new `checkboxradio` support the `label` option, so you can keep using it without any changes. Checkboxradio doesn't have an equivalent of the `text` (old) or `showLabel` (new) option, it will always show the label. It also doesn't have an equivalent of the `icons` (Object, old) or `icon` (String, new) option, you can only turn the checkbox/radio icon on or off using the `icon` (Boolean) option.
+
+## Buttonset
+
+### Deprecated buttonset in favor of controlgroup
+
+The buttonset method, bundled with the button widget, is now deprecated, in favor of the new [controlgroup widget](http://api.jqueryui.com/controlgroup/). If you were using buttonset without any options, migrating to controlgroup only requires a search-and-replace:
+
+```js
+$( ".group" ).buttonset();
+```
+
+New:
+```js
+$( ".group" ).controlgroup();
+```
+
+Controlgroup also has an `items` option, but the signature is different. Instead of listing only the selectors to match button widgets, all supported widgets now have a key in the `item` option, with the selectors as the value:
+
+Old:
+```js
+$( ".group" ).buttonset( {
+	items: "button, span.btn"
+} );
+```
+
+New:
+```js
+$( ".group" ).controlgroup( {
+	items: {
+		button: "button, span.btn"
+	}
+} );
+```
 
 ## Dialog
 

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -9,11 +9,11 @@ This guide will assist in upgrading from jQuery UI 1.11.x to jQuery UI 1.12.x. A
 
 ## General changes
 
-Independent of changes to specific component, this release removes support for IE7, modernizes the theming, including the default font-size, and improves support for AMD. The minimal jQuery version supported is now 1.7.x.
+Independent of changes to specific components, this release removes support for IE7, modernizes the theming, including the default font-size, and improves support for AMD. The minimal jQuery version supported is now 1.7.0.
 
 ### Removed IE7 workarounds
 
-[(#9838)](http://bugs.jqueryui.com/ticket/9838) All IE7 workarounds have been removed from the source code. If need continued IE7 support you can continue to use jQuery UI 1.11.x.
+[(#9838)](http://bugs.jqueryui.com/ticket/9838) All IE7 workarounds have been removed from the source code. If you need continued IE7 support you can continue to use jQuery UI 1.11.x.
 
 ### Font size changes
 
@@ -29,7 +29,7 @@ Independent of changes to specific component, this release removes support for I
 
 ### Split `core.js` into small modules
 
-[(#9647)](http://bugs.jqueryui.com/ticket/9647) The "core" module that uses to bundle various utilities is deprecated. Other source files no longer depend on `core.js`, which is now just a single `define()` call that specifies all the modules it previously bundled as dependencies.
+[(#9647)](http://bugs.jqueryui.com/ticket/9647) The "core" module that used to bundle various utilities is deprecated. Other source files no longer depend on `core.js`, which is now just a single `define()` call that specifies all the modules it previously bundled as dependencies.
 
 ### Moved widgets and effects source files into folders
 
@@ -55,7 +55,7 @@ We hope to move to a format that resembles more of a standard eventually.
 
 ### Removed .zIndex()
 
-[(#9156)](http://bugs.jqueryui.com/ticket/9156) The deprecated `.zIndex()` method has been removed, in favor of the new `.ui-front` / `appendTo` logic used by all widgets that display an element on top of the page, like dialog and autocomplete.
+[(#9156)](http://bugs.jqueryui.com/ticket/9156) The deprecated `.zIndex()` method has been removed, in favor of the new `.ui-front` / `appendTo` [stacking elements](http://api.jqueryui.com/theming/stacking-elements/) logic used by all widgets that display an element on top of the page, like dialog and autocomplete.
 
 This method was used by dialog, but because the dialog now has an [`appendTo` option](http://api.jqueryui.com/dialog/#option-appendTo), this plugin method is no longer necessary. If you are using `.zIndex()`, or building a widget that must stack, check out our [guide to create stacking elements with a `ui-front` class name and `appendTo` option](http://api.jqueryui.com/theming/stacking-elements/).
 
@@ -65,7 +65,7 @@ This method was used by dialog, but because the dialog now has an [`appendTo` op
 
 ## Mouse
 
-### Deprecate distance and delay options
+### Deprecated `distance` and `delay` options
 
 [(#10615)](http://bugs.jqueryui.com/ticket/10615) Interactions should be instantaneous. These settings are typically used to prevent accidental drags, but a proper fix for that is to improve the UX, e.g., using handles to avoid accidental drags.
 
@@ -149,7 +149,8 @@ Old:
 ```js
 $( "button" ).button( {
 	text: false,
-	// still can't hide text without an icon
+
+	// Still can't hide text without an icon
 	icons: {
 		primary: "ui-icon-gear"
 	}
@@ -166,7 +167,9 @@ $( "button" ).button( {
 
 ### Deprecated support for `checkbox` and `radio` types, in favor of checkboxradio widget
 
-If you're using the button widget with one of these input types, replace it with the new [checkboxradio widget](http://api.jqueryui.com/checkboxradio/):
+With the introduction of the new [checkboxradio widget](http://api.jqueryui.com/checkboxradio/), the button widget is no longer intended to be used as a toggle button. However, with back-compat enabled, the button widget will automatically detect if you're trying to create a button from a checkbox or radio button and call `.checkboxradio()` on those elements for you.
+
+If you're using the button widget with one of these input types, replace it with the new checkboxradio widget:
 
 Old:
 ```js
@@ -208,7 +211,7 @@ $( "input[type=checkbox]" ).checkboxradio({
 
 ### Deprecated buttonset in favor of controlgroup
 
-The buttonset method, bundled with the button widget, is now deprecated, in favor of the new [controlgroup widget](http://api.jqueryui.com/controlgroup/). If you were using buttonset without any options, migrating to controlgroup only requires a search-and-replace:
+The buttonset widget, bundled with the button widget, is now deprecated, in favor of the new [controlgroup widget](http://api.jqueryui.com/controlgroup/). If you were using buttonset without any options, migrating to controlgroup only requires a search-and-replace:
 
 ```js
 $( ".group" ).buttonset();
@@ -219,7 +222,7 @@ New:
 $( ".group" ).controlgroup();
 ```
 
-Controlgroup also has an `items` option, but the signature is different. Instead of listing only the selectors to match button widgets, all supported widgets now have a key in the `item` option, with the selectors as the value:
+Controlgroup also has an `items` option, but the signature is different. Instead of listing only the selectors to match button widgets, all supported widgets now have a key in the `items` option, with the selectors as the value:
 
 Old:
 ```js
@@ -241,7 +244,7 @@ $( ".group" ).controlgroup( {
 
 ### Deprecated `dialogClass` in favor of `classes.ui-dialog`
 
-[(#12161)](http://bugs.jqueryui.com/ticket/12161) The `dialogClass` option is now deprecated. Use the new `classes` option with the `"ui-dialog"` property instead.
+[(#12161)](http://bugs.jqueryui.com/ticket/12161) The `dialogClass` option is now deprecated. Use the new [`classes`](http://api.jqueryui.com/dialog/#option-classes) option with the `ui-dialog` property instead.
 
 Old:
 ```js
@@ -263,7 +266,7 @@ $( ".content" ).dialog( {
 
 ### Deprecated `activeClass` in favor of `classes.ui-droppable-active`
 
-[(#12162)](http://bugs.jqueryui.com/ticket/12162) The `activeClass` option is now deprecated. Use the new `classes` option with the `"ui-droppable-active"` property instead.
+[(#12162)](http://bugs.jqueryui.com/ticket/12162) The `activeClass` option is now deprecated. Use the new [`classes`](http://api.jqueryui.com/droppable/#option-classes) option with the `ui-droppable-active` property instead.
 
 Old:
 ```js
@@ -283,7 +286,7 @@ $( ".target" ).droppable( {
 
 ### Deprecated `hoverClass` in favor of `classes.ui-droppable-hover`
 
-[(#12162)](http://bugs.jqueryui.com/ticket/12162) The `hoverClass` option is now deprecated. Use the new `classes` option with the `"ui-droppable-hover"` property instead.
+[(#12162)](http://bugs.jqueryui.com/ticket/12162) The `hoverClass` option is now deprecated. Use the new [`classes`](http://api.jqueryui.com/droppable/#option-classes) option with the `ui-droppable-hover` property instead.
 
 Old:
 ```js
@@ -339,7 +342,7 @@ The autocomplete and selectmenu widgets, which both use menu internally, were bo
 
 ### Use consistent styling for focused and active items
 
-[(#10692)](http://bugs.jqueryui.com/ticket/10692) We used to style active parent menu items with "ui-state-active", while everything else got "ui-state-focus" (or hover, which we style the same as focus). When a menu item in a submenu has focus, the parent menu item gets "ui-state-active", which is inconsistent and confusing. We've now switched to using only the "ui-state-active" class.
+[(#10692)](http://bugs.jqueryui.com/ticket/10692) We used to style active parent menu items with `ui-state-active`, while everything else got `ui-state-focus` (or `ui-state-hover`, which we style the same as focus). When a menu item in a submenu has focus, the parent menu item gets `ui-state-active`, which is inconsistent and confusing. We've now switched to using only the `ui-state-active` class.
 
 ## Selectmenu
 
@@ -349,7 +352,7 @@ The autocomplete and selectmenu widgets, which both use menu internally, were bo
 
 ### Support `width: false` and default to 14em
 
-[(#11198)](http://bugs.jqueryui.com/ticket/11198) `width: null` still matches the width of the original element. `width: false` prevents an inline style from being set for the width. This makes it easy to set the width via a stylesheet and allows the use of any unit for setting the width, such as the new default of 14em.
+[(#11198)](http://bugs.jqueryui.com/ticket/11198) `width: null` still matches the width of the original element. `width: false` prevents an inline style from being set for the width. This makes it easy to set the width via a stylesheet and allows the use of any unit for setting the width, such as the new default of 14em, which is set through the stylesheet.
 
 ### Uses `button.css`
 
@@ -365,7 +368,7 @@ Instead of duplicating CSS, the selectmenu widget now reuses classes defined in 
 
 ### Deprecated `tooltipClass` in favor of `classes.ui-tooltip`
 
-[(#12167)](http://bugs.jqueryui.com/ticket/12167) The `tooltipClass` option is now deprecated. Use the new `classes` option with the `"ui-tooltip"` property instead.
+[(#12167)](http://bugs.jqueryui.com/ticket/12167) The `tooltipClass` option is now deprecated. Use the new [`classes`](http://api.jqueryui.com/tooltip/#option-classes) option with the `ui-tooltip` property instead.
 
 Old:
 ```js
@@ -385,13 +388,13 @@ $( ".content" ).tooltip( {
 
 ### Allow DOM elements and jQuery objects as content
 
-[(#9278)](http://bugs.jqueryui.com/ticket/9278) Tooltip now accepts HTMLElement and jQuery objects for the content option.
+[(#9278)](http://bugs.jqueryui.com/ticket/9278) Tooltip now accepts HTMLElement and jQuery objects for the `content` option.
 
 ## Widget
 
 ### Ability to customize style-related CSS classes
 
-[(#7053)](http://bugs.jqueryui.com/ticket/7053) jQuery UI used to hardcode classes like `.ui-corner-all` in widgets. We removed the hardcoding and added the ability to customize the style-related classes based on the functional classes. For the dialog, droppable and tooltip widgets, we replaced options that were doing just that.
+[(#7053)](http://bugs.jqueryui.com/ticket/7053) jQuery UI used to hardcode classes like `ui-corner-all` in widgets. We removed the hardcoding and added the ability to customize the style-related classes based on the functional classes. For the dialog, droppable and tooltip widgets, we replaced options that were doing just that.
 
 Here's an example using dialog:
 ```js
@@ -403,9 +406,11 @@ $( "#dialog" ).dialog( {
 } );
 ```
 
+This will add the `ui-corner-top` and `awesome-fade-class` classes to the element which has the `ui-dialog` class, while also removing the default `ui-corner-all` class from the element which has the `ui-dialog-titlebar` class.
+
 ## Effects
 
-### Make transfer effect a jQuery plugin method
+### Converted transfer effect to a jQuery plugin method
 
 The transfer effect was available through the extended `.show()`, `.hide()` and `.toggle()` methods, which was a side-effect of exposing it as an effect, but made no semantic sense. The effect is now available exclusively through the `.transfer()` method.
 

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -96,6 +96,31 @@ $( "button" ).button( {
 } );
 ```
 
+Replacing a button with two icons can be accomplished by putting one icon in the markup:
+
+Old:
+```html
+<button>Click me</button>
+```
+```js
+$( "button" ).button( {
+	icons: {
+		primary: "ui-icon-lock",
+		secondary: "ui-icon-gear"
+	}
+} );
+```
+
+New:
+```html
+<button>Click me <span class="ui-icon ui-icon-gear"></span></button>
+```
+```js
+$( "button" ).button( {
+	icon: "ui-icon-lock"
+} );
+```
+
 ### Deprecated `text` option in favor of `showLabel`
 
 This option was renamed for clarity, otherwise it hasn't changed.
@@ -119,7 +144,7 @@ $( "button" ).button( {
 } );
 ```
 
-### Deprecated support for `input[type=checkbox]` and `input[type=radio]`, in favor of the new checkboxradio widget
+### Deprecated support for `checkbox` and `radio` types, in favor of checkboxradio widget
 
 If you're using the button widget with one of these input types, replace it with the new [checkboxradio widget](http://api.jqueryui.com/checkboxradio/):
 
@@ -133,7 +158,31 @@ New:
 $( "input[type=checkbox]" ).checkboxradio();
 ```
 
-Both old and new `button` and new `checkboxradio` support the `label` option, so you can keep using it without any changes. Checkboxradio doesn't have an equivalent of the `text` (old) or `showLabel` (new) option, it will always show the label. It also doesn't have an equivalent of the `icons` (Object, old) or `icon` (String, new) option, you can only turn the checkbox/radio icon on or off using the `icon` (Boolean) option.
+Both old and new `button` and new `checkboxradio` support the `label` option, so you can keep using it without any changes. Checkboxradio doesn't have an equivalent of the `text` (old) or `showLabel` (new) option, it will always show the label. It also doesn't have an equivalent of the `icons` (Object, old) or `icon` (String, new) option, you can only turn the checkbox/radio icon on or off using the `icon` (Boolean) option. To replace a toggle button with a custom icon (no checkmark), turn off the icon and add a custom icon to the markup.
+
+Old:
+```html
+<input type="checkbox" id="metal">
+<label for="metal">Metal Checkbox</label>
+```
+```js
+$( "input[type=checkbox]" ).button( {
+	icons: {
+		primary: "ui-icon-gear"
+	}
+} );
+```
+
+New:
+```html
+<input type="checkbox" id="metal">
+<label for="metal"><span class="ui-icon ui-icon-gear"></span> Metal Checkbox</label>
+```
+```js
+$( "input[type=checkbox]" ).checkboxradio({
+	icon: false
+});
+```
 
 ## Buttonset
 
@@ -282,7 +331,9 @@ The autocomplete and selectmenu widgets, which both use menu internally, were bo
 
 [(#11198)](http://bugs.jqueryui.com/ticket/11198) `width: null` still matches the width of the original element. `width: false` prevents an inline style from being set for the width. This makes it easy to set the width via a stylesheet and allows the use of any unit for setting the width, such as the new default of 14em.
 
+### Uses `button.css`
 
+Instead of duplicating CSS, the selectmenu widget now reuses classes defined in `button.css`. If you're building jQuery UI manually, you need to include `button.css` as a dependency for selectmenu.
 
 ## Tabs
 

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -27,6 +27,14 @@ Independent of changes to specific component, this release removes support for I
 
 [(#10723)](http://bugs.jqueryui.com/ticket/10723) jQuery UI no longer supports jQuery 1.6. The minimal supported version is now 1.7.0.
 
+### Split `core.js` into small modules
+
+[(#9647)](http://bugs.jqueryui.com/ticket/9647) The "core" module that uses to bundle various utilities is deprecated. Other source files no longer depend on `core.js`, which is now just a single `define()` call that specifies all the modules it previously bundled as dependencies.
+
+### Moved widgets and effects source files into folders
+
+[(#13885)](http://bugs.jqueryui.com/ticket/13885) All widgets, including `mouse.js` (but excluding `widget.js`) were moved to a `widgets` subfolder, so for example, the source for the autocomplete widget is now `ui/widgets/autocomplete.js`. Similarily, all effects (except `effect.js`) were moved to an `effects` subfolder.
+
 ## Core
 
 ### Removed .focus( delay )

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -75,7 +75,7 @@ The button widget underwent a rewrite in this release. Most notably, support for
 
 ### Deprecated `icons` options in favor of `icon` and `iconPosition`
 
-The button widget used to have an `icons` option that supported `primary` and `secondary` properties, allowing up to two icons at once. This has been replaced by the `icon` option, which only allows a single icon, and the `iconPosition` option, which controls the placement of that one icon.
+[(#14744)](http://bugs.jqueryui.com/ticket/14744) The button widget used to have an `icons` option that supported `primary` and `secondary` properties, allowing up to two icons at once. This has been replaced by the `icon` option, which only allows a single icon, and the `iconPosition` option, which controls the placement of that one icon.
 
 The equivalent of the old `primary` icons property is `iconPosition: "beginning"`, while the equivalent of the old `secondary` icons property is `iconPosition: "end"`. The new button also supports "top" and "bottom" for `iconPosition`, allowing the icon to be displayed above or below the button text.
 
@@ -143,7 +143,7 @@ $( "button" ).button( {
 
 ### Deprecated `text` option in favor of `showLabel`
 
-This option was renamed for clarity, otherwise it hasn't changed.
+[(#8203)](http://bugs.jqueryui.com/ticket/8203) This option was renamed for clarity, otherwise it hasn't changed.
 
 Old:
 ```js
@@ -167,7 +167,7 @@ $( "button" ).button( {
 
 ### Deprecated support for `checkbox` and `radio` types, in favor of checkboxradio widget
 
-With the introduction of the new [checkboxradio widget](http://api.jqueryui.com/checkboxradio/), the button widget is no longer intended to be used as a toggle button. However, with back-compat enabled, the button widget will automatically detect if you're trying to create a button from a checkbox or radio button and call `.checkboxradio()` on those elements for you.
+[(#14746)](http://bugs.jqueryui.com/ticket/14746) With the introduction of the new [checkboxradio widget](http://api.jqueryui.com/checkboxradio/), the button widget is no longer intended to be used as a toggle button. However, with back-compat enabled, the button widget will automatically detect if you're trying to create a button from a checkbox or radio button and call `.checkboxradio()` on those elements for you.
 
 If you're using the button widget with one of these input types, replace it with the new checkboxradio widget:
 
@@ -211,7 +211,7 @@ $( "input[type=checkbox]" ).checkboxradio({
 
 ### Deprecated buttonset in favor of controlgroup
 
-The buttonset widget, bundled with the button widget, is now deprecated, in favor of the new [controlgroup widget](http://api.jqueryui.com/controlgroup/). If you were using buttonset without any options, migrating to controlgroup only requires a search-and-replace:
+[(#14747)](http://bugs.jqueryui.com/ticket/14747) The buttonset widget, bundled with the button widget, is now deprecated, in favor of the new [controlgroup widget](http://api.jqueryui.com/controlgroup/). If you were using buttonset without any options, migrating to controlgroup only requires a search-and-replace:
 
 ```js
 $( ".group" ).buttonset();
@@ -412,7 +412,7 @@ This will add the `ui-corner-top` and `awesome-fade-class` classes to the elemen
 
 ### Converted transfer effect to a jQuery plugin method
 
-The transfer effect was available through the extended `.show()`, `.hide()` and `.toggle()` methods, which was a side-effect of exposing it as an effect, but made no semantic sense. The effect is now available exclusively through the `.transfer()` method.
+[(#14749)](http://bugs.jqueryui.com/ticket/14749) The transfer effect was available through the extended `.show()`, `.hide()` and `.toggle()` methods, which was a side-effect of exposing it as an effect, but made no semantic sense. The effect is now available exclusively through the `.transfer()` method.
 
 Old:
 ```js

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -1,0 +1,51 @@
+<script>{
+	"title": "jQuery UI 1.12 Upgrade Guide",
+	"toc": true
+}</script>
+
+## Overview
+
+This guide will assist in upgrading from jQuery UI 1.11.x to jQuery UI 1.12.x. All changes are listed below, organized by plugin, along with how to upgrade your code to work with jQuery UI 1.12.
+
+## General changes
+
+...
+
+### Removed IE7 workarounds
+
+[(#9838)](http://bugs.jqueryui.com/ticket/9838) All IE7 workarounds have been removed from the source code. If need continued IE7 support you can continue to use jQuery UI 1.11.x.
+
+### Font size changes
+
+...
+
+## Menu
+
+### Menu items now require wrappers
+
+[(#10162)](http://bugs.jqueryui.com/ticket/10162) To resolve [several styling issues](http://bugs.jqueryui.com/ticket/10162), the menu widget now requires each menu item to be wrapped with a DOM element. The example below uses `<div>` elements for wrappers, but you can use any block-level element.
+
+Old:
+
+```
+<ul id="menu">
+	<li>One</li>
+	<li>Two</li>
+</ul>
+```
+
+New:
+
+```
+<ul id="menu">
+	<li>
+		<div>One</div>
+	</li>
+	<li>
+		<div>Two</div>
+	</li>
+</ul>
+```
+
+The autocomplete and selectmenu widgets, which both use menu internally, were both updated to include wrappers.
+

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -35,6 +35,18 @@ Independent of changes to specific component, this release removes support for I
 
 [(#13885)](http://bugs.jqueryui.com/ticket/13885) All widgets, including `mouse.js` (but excluding `widget.js`) were moved to a `widgets` subfolder, so for example, the source for the autocomplete widget is now `ui/widgets/autocomplete.js`. Similarily, all effects (except `effect.js`) were moved to an `effects` subfolder.
 
+### Explicit CSS dependencies
+
+In jQuery UI 1.11 we added support for AMD dependency management, but this applied only for JS files. CSS files still had to be managed manually (though download builder helps). In 1.12 all JS components now explicitly list their non-transient CSS dependencies, through structured source comments. For example, `widgets/autocomplete.js` has these comments:
+```js
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/autocomplete.css
+//>>css.theme: ../../themes/base/theme.css
+```
+Download builder parses these to resolve each JS component's CSS dependencies. Other build tools like requirejs or webpack could also parse these (and make it reusable through plugins).
+
+We hope to move to a format that resembles more of a standard eventually.
+
 ## Core
 
 ### Removed .focus( delay )


### PR DESCRIPTION
Replaces #107, now targets the 1-12 branch.

Still missing:

* [x] Button: API, dropping support for radio/checkbox
* [ ] Button: CSS only buttons
* [x] Buttonset: Replaced by controlgroup
* [ ] Effects: See [API issue](https://github.com/jquery/api.jqueryui.com/issues/242), what do we need to document here except for the transfer effect?
* [ ] Renamed minified files, see [#10674](http://bugs.jqueryui.com/ticket/10674), do we need to mention this?