### PR TITLE
Travis: Setup CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: false
+addons:
+  apt:
+    packages:
+    - imagemagick
+language: node_js
+node_js:
+  - "0.12"
+before_script:
+  - npm install -g grunt-cli
+  - cp config-sample.json config.json

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
       "url": "https://github.com/jquery/api.jquery.com/blob/master/LICENSE.txt"
     }
   ],
+  "scripts": {
+    "test": "grunt build --stack"
+  },
   "dependencies": {
     "cheerio": "0.12.4",
     "download.jqueryui.com": "2.0.25",


### PR DESCRIPTION
I'm trying to build this repo on Travis. There are no tests, but just having each commit build all the resources would still be a big improvement over doing nothing.

Currently the build is failing as the build-download task (no surpirse there), with the useless error "Fatal error: Missing ./../jquery-ui/1.10.4 folder. Run `grunt prepare` first, or fix your config file." -> https://travis-ci.org/jquery/jqueryui.com/builds/88074295

@rxaviers do you remember what's causing this? I'm sure I've seen it before, but I don't know what's going on this time. I've tried adding both xsltproc and imagemagick apt packages, but while both might be needed at a later point, that's not the cause of the current failure.