### PR TITLE
1.12 Upgrade Guide: Add all `distance` and `delay` deprecrations

### DIFF
--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -67,7 +67,7 @@ This method was used by dialog, but because the dialog now has an [`appendTo` op
 
 ### Deprecated `distance` and `delay` options
 
-[(#10615)](http://bugs.jqueryui.com/ticket/10615) Interactions should be instantaneous. These settings are typically used to prevent accidental drags, but a proper fix for that is to improve the UX, e.g., using handles to avoid accidental drags.
+[(#10615)](http://bugs.jqueryui.com/ticket/10615) Interactions should be instantaneous. These settings are typically used to prevent accidental drags, but a proper fix for that is to improve the user experience, e.g., using handles to avoid accidental drags.
 
 ## Button
 
@@ -262,6 +262,12 @@ $( ".content" ).dialog( {
 } );
 ```
 
+## Draggable
+
+### Deprecated `distance` and `delay` options
+
+See [the notes for the mouse widget](#deprecated-distance-and-delay-options).
+
 ## Droppable
 
 ### Deprecated `activeClass` in favor of `classes.ui-droppable-active`
@@ -344,6 +350,18 @@ The autocomplete and selectmenu widgets, which both use menu internally, were bo
 
 [(#10692)](http://bugs.jqueryui.com/ticket/10692) We used to style active parent menu items with `ui-state-active`, while everything else got `ui-state-focus` (or `ui-state-hover`, which we style the same as focus). When a menu item in a submenu has focus, the parent menu item gets `ui-state-active`, which is inconsistent and confusing. We've now switched to using only the `ui-state-active` class.
 
+## Resizable
+
+### Deprecated `distance` and `delay` options
+
+See [the notes for the mouse widget](#deprecated-distance-and-delay-options).
+
+## Selectable
+
+### Deprecated `distance` and `delay` options
+
+See [the notes for the mouse widget](#deprecated-distance-and-delay-options).
+
 ## Selectmenu
 
 ### Added `_renderButtonItem()` method
@@ -357,6 +375,12 @@ The autocomplete and selectmenu widgets, which both use menu internally, were bo
 ### Uses `button.css`
 
 Instead of duplicating CSS, the selectmenu widget now reuses classes defined in `button.css`. If you're building jQuery UI manually, you need to include `button.css` as a dependency for selectmenu.
+
+## Sortable
+
+### Deprecated `distance` and `delay` options
+
+See [the notes for the mouse widget](#deprecated-distance-and-delay-options).
 
 ## Tabs
 


### PR DESCRIPTION
We should probably list this for every interaction so that users don't need to know about the inheritance.