### PR TITLE
1.12 Upgrade Guide: Add notes about API redesigns

### DIFF
--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -7,6 +7,24 @@
 
 This guide will assist in upgrading from jQuery UI 1.11.x to jQuery UI 1.12.x. All changes are listed below, organized by plugin, along with how to upgrade your code to work with jQuery UI 1.12.
 
+## API Redesigns
+
+jQuery UI 1.12 introduces API redesigns for Button, Buttonset, Dialog, Draggable, Droppable, Menu, Mouse, Resizable, Selectable, Sortable, Tabs, Tooltip, and Effects. You can read about the API redesign process on the
+[jQuery UI Blog](http://blog.jqueryui.com/2011/03/api-redesigns-the-past-present-and-future/). Although the redesigns introduce breaking changes, **1.12 maintains a lot of compatibility with the 1.11 API by default.** This is accomplished by rebuilding the 1.11 API on top of the 1.12 API. The default behavior for all 1.12 releases will be to simultaneously use the 1.11 and 1.12 APIs where possible. If you would like to load just the 1.12 API without the 1.11 API, you can set the `$.uiBackCompat` flag to `false`.
+
+```html
+<script src="jquery.js"></script>
+<script>$.uiBackCompat = false;</script>
+<script src="jquery-ui.js"></script>
+```
+
+### Preparing for jQuery UI 1.13
+
+The API redesigns deprecate some functionality, which will be removed in 1.13. You don't have to wait for the 1.13.0 release in order to find out if your code will work when the 1.11 APIs are removed. You can use the `$.uiBackCompat` flag to test this with any 1.12 release.
+
+<p class="note">If you find a regression from the 1.11 API, please report it in the [bug tracker](http://bugs.jqueryui.com/newticket). Even though the 1.11 API is deprecated, it's important for 1.12 releases not to regress so that users are encouraged to upgrade even if they're not ready to use the new APIs. Note that
+most 1.10 APIs which were deprecated in 1.11 were removed in 1.12 and will not exist, regardless of the `$.uiBackCompat` flag.</p>
+
 ## General changes
 
 Independent of changes to specific components, this release removes support for IE7, modernizes the theming, including the default font-size, and improves support for AMD. The minimal jQuery version supported is now 1.7.0.
@@ -68,6 +86,8 @@ This method was used by dialog, but because the dialog now has an [`appendTo` op
 ### Deprecated `distance` and `delay` options
 
 [(#10615)](http://bugs.jqueryui.com/ticket/10615) Interactions should be instantaneous. These settings are typically used to prevent accidental drags, but a proper fix for that is to improve the user experience, e.g., using handles to avoid accidental drags.
+
+<p class="note">Unlike most deprecated APIs which only remain for one version before being removed, the `distance` and `delay` options for each interaction won't be removed until the respective rewrites are included in a new version. The only interaction rewrite that is currently planned to be released in 1.13.0 is draggable. As such, the `$.uiBackCompat` flag won't remove the options from the API.</p>
 
 ## Button
 


### PR DESCRIPTION
I'd actually like to implement `$.uiBackCompat` for the `distance` and `delay` options in draggable before the release. Once that's implemented, we'll need a slight tweak to this message, but as of right now, this should all be correct.