### PR TITLE
Index: 1.12.0 needs jQuery 1.7+

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -19,7 +19,7 @@
 		<div class="download-option">
 			<a href="/resources/download/jquery-ui-1.12.0.zip" class="button">Stable</a>
 			<span>v1.12.0</span>
-			<span>jQuery 1.6+</span>
+			<span>jQuery 1.7+</span>
 		</div>
 		<div class="download-option">
 			<a href="/resources/download/jquery-ui-1.11.4.zip" class="button">Legacy</a>


### PR DESCRIPTION
According to http://jqueryui.com/upgrade-guide/1.12/#dropped-support-for-jquery-1-6