### PR TITLE
All: Improve 1.13.* changelogs & the upgrade guide

### DIFF
--- a/page/changelog/1.13.0-rc.2.md
+++ b/page/changelog/1.13.0-rc.2.md
@@ -13,88 +13,88 @@ Released on September 3, 2021
 
 ### UI Core
 
-* Fixed: Rename from `.form()` to `._form()` since its not for public use ([#15074](https://bugs.jqueryui.com/ticket/15074), [0627eb364](https://github.com/jquery/jquery-ui/commit/0627eb3645009d868ae20a27d0a283acd5797a1f))
-* Fixed: Handle empty sets in Labels ([#15184](https://bugs.jqueryui.com/ticket/15184), [adcf9b6f6](https://github.com/jquery/jquery-ui/commit/adcf9b6f6ef9c6dfa88932b40307f581e65bc667))
-* Removed: `$.ui.escapeSelector` in favor of `$.escapeSelector` ([#14991](https://bugs.jqueryui.com/ticket/14991), [7c6a9f012](https://github.com/jquery/jquery-ui/commit/7c6a9f01281a9739f54ef57d7deecb41a873ef38))
+* Fixed: Rename from `.form()` to `._form()` since its not for public use ([trac-15074](https://bugs.jqueryui.com/ticket/15074), [0627eb364](https://github.com/jquery/jquery-ui/commit/0627eb3645009d868ae20a27d0a283acd5797a1f))
+* Fixed: Handle empty sets in Labels ([trac-15184](https://bugs.jqueryui.com/ticket/15184), [adcf9b6f6](https://github.com/jquery/jquery-ui/commit/adcf9b6f6ef9c6dfa88932b40307f581e65bc667))
+* Removed: `$.ui.escapeSelector` in favor of `$.escapeSelector` ([trac-14991](https://bugs.jqueryui.com/ticket/14991), [7c6a9f012](https://github.com/jquery/jquery-ui/commit/7c6a9f01281a9739f54ef57d7deecb41a873ef38))
 
 ### Widget Factory
 
 * Fixed: Boolean option when under use strict ([2434dfd45](https://github.com/jquery/jquery-ui/commit/2434dfd45d0805304e1db634d059feaa0bacf358))
-* Fixed: Handle `Object.create(null)` for options objects ([#15179](https://bugs.jqueryui.com/ticket/15179), [b3c0a7f71](https://github.com/jquery/jquery-ui/commit/b3c0a7f71d0b351755b97858ad47de4e9a373606))
-* Fixed: Improve `remove` event bindings for `classes` options ([#15078](https://bugs.jqueryui.com/ticket/15078), [#15082](https://bugs.jqueryui.com/ticket/15082), [#15095](https://bugs.jqueryui.com/ticket/15095), [#15136](https://bugs.jqueryui.com/ticket/15136), [#15152](https://bugs.jqueryui.com/ticket/15152), [ef2e9bab9](https://github.com/jquery/jquery-ui/commit/ef2e9bab92ae898311baa295590cd487d9071319))
+* Fixed: Handle `Object.create(null)` for options objects ([trac-15179](https://bugs.jqueryui.com/ticket/15179), [b3c0a7f71](https://github.com/jquery/jquery-ui/commit/b3c0a7f71d0b351755b97858ad47de4e9a373606))
+* Fixed: Improve `remove` event bindings for `classes` options ([trac-15078](https://bugs.jqueryui.com/ticket/15078), [trac-15082](https://bugs.jqueryui.com/ticket/15082), [trac-15095](https://bugs.jqueryui.com/ticket/15095), [trac-15136](https://bugs.jqueryui.com/ticket/15136), [trac-15152](https://bugs.jqueryui.com/ticket/15152), [ef2e9bab9](https://github.com/jquery/jquery-ui/commit/ef2e9bab92ae898311baa295590cd487d9071319))
 * Fixed: Don't swallow errors in `remove` events ([1f2011ece](https://github.com/jquery/jquery-ui/commit/1f2011ece3fe6847874677e9a8210fa202498ccb))
 
 ## Widgets
 
 ### Autocomplete
 
-* Fixed: IE/Edge scrolling issues ([#9638](https://bugs.jqueryui.com/ticket/9638), [573e7e69c](https://github.com/jquery/jquery-ui/commit/573e7e69c9b63752fb06a15d60ec2dded839e093))
-* Fixed: Escape HTML tags in callback name to avoid XSS in demo ([#15048](https://bugs.jqueryui.com/ticket/15048), [69e66ea65](https://github.com/jquery/jquery-ui/commit/69e66ea6556584c39621c184f8f790a1011408ce))
+* Fixed: IE/Edge scrolling issues ([trac-9638](https://bugs.jqueryui.com/ticket/9638), [573e7e69c](https://github.com/jquery/jquery-ui/commit/573e7e69c9b63752fb06a15d60ec2dded839e093))
+* Fixed: Escape HTML tags in callback name to avoid XSS in demo ([trac-15048](https://bugs.jqueryui.com/ticket/15048), [69e66ea65](https://github.com/jquery/jquery-ui/commit/69e66ea6556584c39621c184f8f790a1011408ce))
 
 ### Button
 
-* Fixed: Backcompat when called on collection of mixed elements ([#15109](https://bugs.jqueryui.com/ticket/15109), [abc9e7ce2](https://github.com/jquery/jquery-ui/commit/abc9e7ce2f3b60a18bf1f461c7cbfccb3fa02b53))
+* Fixed: Backcompat when called on collection of mixed elements ([trac-15109](https://bugs.jqueryui.com/ticket/15109), [abc9e7ce2](https://github.com/jquery/jquery-ui/commit/abc9e7ce2f3b60a18bf1f461c7cbfccb3fa02b53))
 
 ### Checkboxradio
 
-* Fixed: Don't add ui-state-hover to icons ([#15055](https://bugs.jqueryui.com/ticket/15055), [b9d687deb](https://github.com/jquery/jquery-ui/commit/b9d687deb58cce5f4c6e27dace9cb172e291698c))
+* Fixed: Don't add ui-state-hover to icons ([trac-15055](https://bugs.jqueryui.com/ticket/15055), [b9d687deb](https://github.com/jquery/jquery-ui/commit/b9d687deb58cce5f4c6e27dace9cb172e291698c))
 
 ### Datepicker
 
 * Added: Add option for `onUpdateDatepicker` callback ([17d115b82](https://github.com/jquery/jquery-ui/commit/17d115b8298b935ab0d26b881d4f6f3e83984868), [a12c98574](https://github.com/jquery/jquery-ui/commit/a12c98574d07f002fd59d166f9fc1fd391581b91))
 * Added: German localization ([ddbcc5d29](https://github.com/jquery/jquery-ui/commit/ddbcc5d29d069336ddaeab221db91220b95da175))
 * Fixed: Get `selectedDay` from `data-date` instead of element contents ([cf938e286](https://github.com/jquery/jquery-ui/commit/cf938e286382cc8f6cb74b3c6f75275073672aeb))
-* Fixed: Make sure text options are text, shorten HTML strings ([#15284](https://bugs.jqueryui.com/ticket/15284), [afe20b79a](https://github.com/jquery/jquery-ui/commit/afe20b79a64266e64011f34b26a30b3d1c62fd47))
+* Fixed: Make sure text options are text, shorten HTML strings ([trac-15284](https://bugs.jqueryui.com/ticket/15284), [afe20b79a](https://github.com/jquery/jquery-ui/commit/afe20b79a64266e64011f34b26a30b3d1c62fd47))
 * Fixed: Make sure `altField` is treated as a CSS selector ([32850869d](https://github.com/jquery/jquery-ui/commit/32850869d308d5e7c9bf3e3b4d483ea886d373ce))
 * Fixed: Hungarian localization to use uppercase for first characters ([9bb366ef8](https://github.com/jquery/jquery-ui/commit/9bb366ef8a710c06df924b2f6567cd5ed701cd44))
 * Fixed: Current instance memory leak and added unit testcases ([817ce3855](https://github.com/jquery/jquery-ui/commit/817ce38555f07981f929fb4b1229fc42574cf85c))
 * Fixed: Typo in `currentText` in `da` localization ([9c0d83f2e](https://github.com/jquery/jquery-ui/commit/9c0d83f2e55f6b33e650f8dcd6b53866601695fd))
-* Fixed: First day of week for `pt-PT` locale ([#15195](https://bugs.jqueryui.com/ticket/15195), [6fdd0e34a](https://github.com/jquery/jquery-ui/commit/6fdd0e34a74789d2da214739ea0f5a8feff71d7e))
-* Fixed: Swedish localization ([#15142](https://bugs.jqueryui.com/ticket/15142), [032ddc334](https://github.com/jquery/jquery-ui/commit/032ddc3349f625e0840aa8e266b5d8ebee994853))
-* Fixed: Prev/next button behavior with `showCurrentAtPos` ([#15102](https://bugs.jqueryui.com/ticket/15102), [17404ced4](https://github.com/jquery/jquery-ui/commit/17404ced478a235651513fa7bef3473ef1b039e8))
-* Fixed: Traditional Chinese translation ([#15060](https://bugs.jqueryui.com/ticket/15060), [129434384](https://github.com/jquery/jquery-ui/commit/12943438478e71db02e861b02cd406429fc3b080))
+* Fixed: First day of week for `pt-PT` locale ([trac-15195](https://bugs.jqueryui.com/ticket/15195), [6fdd0e34a](https://github.com/jquery/jquery-ui/commit/6fdd0e34a74789d2da214739ea0f5a8feff71d7e))
+* Fixed: Swedish localization ([trac-15142](https://bugs.jqueryui.com/ticket/15142), [032ddc334](https://github.com/jquery/jquery-ui/commit/032ddc3349f625e0840aa8e266b5d8ebee994853))
+* Fixed: Prev/next button behavior with `showCurrentAtPos` ([trac-15102](https://bugs.jqueryui.com/ticket/15102), [17404ced4](https://github.com/jquery/jquery-ui/commit/17404ced478a235651513fa7bef3473ef1b039e8))
+* Fixed: Traditional Chinese translation ([trac-15060](https://bugs.jqueryui.com/ticket/15060), [129434384](https://github.com/jquery/jquery-ui/commit/12943438478e71db02e861b02cd406429fc3b080))
 * Fixed: Adapt `datepicker.js` for a11y ([b864cd103](https://github.com/jquery/jquery-ui/commit/b864cd103a0acb76b0a34fb1dd382dc0925ef9a8))
 
 ### Dialog
 
 * Fixed: Broken focus re-triggering in jQuery 3.4/3.5 ([834ee5f7c](https://github.com/jquery/jquery-ui/commit/834ee5f7cfb621b5f75292915a00319927a9a6d0))
-* Fixed: Shared event handler for modal dialogs ([#15182](https://bugs.jqueryui.com/ticket/15182), [5708046ea](https://github.com/jquery/jquery-ui/commit/5708046ea1ba4d6d86f431ec9fd32d28ae7542f6))
+* Fixed: Shared event handler for modal dialogs ([trac-15182](https://bugs.jqueryui.com/ticket/15182), [5708046ea](https://github.com/jquery/jquery-ui/commit/5708046ea1ba4d6d86f431ec9fd32d28ae7542f6))
 
 ### Menu
 
 * Fixed: Account for scrollbars in jQuery 3.2 ([1712b9bbb](https://github.com/jquery/jquery-ui/commit/1712b9bbb2e214819508b00d8f318713e27cd949))
-* Fixed: Ignore mouse events triggered due to page scrolling ([#9356](https://bugs.jqueryui.com/ticket/9356), [50efd6e1b](https://github.com/jquery/jquery-ui/commit/50efd6e1b063822c4a0ecb38f324ed3354f387c4))
-* Fixed: Handle mouse movement mixed with keyboard navigation ([#9357](https://bugs.jqueryui.com/ticket/9357), [7d992ae29](https://github.com/jquery/jquery-ui/commit/7d992ae29d27cdab8787691a14e689e60c74c05c))
-* Fixed: Don't focus dividers when wrapping via keyboard navigation ([#15157](https://bugs.jqueryui.com/ticket/15157), [a3e953b49](https://github.com/jquery/jquery-ui/commit/a3e953b495905d0c67790e65032841451b470ce1))
-* Fixed: Close menus immediately on selection or click outside ([#15034](https://bugs.jqueryui.com/ticket/15034), [0d25a36ee](https://github.com/jquery/jquery-ui/commit/0d25a36eecb9e5598596208e4852b3c3fdbf5510))
+* Fixed: Ignore mouse events triggered due to page scrolling ([trac-9356](https://bugs.jqueryui.com/ticket/9356), [50efd6e1b](https://github.com/jquery/jquery-ui/commit/50efd6e1b063822c4a0ecb38f324ed3354f387c4))
+* Fixed: Handle mouse movement mixed with keyboard navigation ([trac-9357](https://bugs.jqueryui.com/ticket/9357), [7d992ae29](https://github.com/jquery/jquery-ui/commit/7d992ae29d27cdab8787691a14e689e60c74c05c))
+* Fixed: Don't focus dividers when wrapping via keyboard navigation ([trac-15157](https://bugs.jqueryui.com/ticket/15157), [a3e953b49](https://github.com/jquery/jquery-ui/commit/a3e953b495905d0c67790e65032841451b470ce1))
+* Fixed: Close menus immediately on selection or click outside ([trac-15034](https://bugs.jqueryui.com/ticket/15034), [0d25a36ee](https://github.com/jquery/jquery-ui/commit/0d25a36eecb9e5598596208e4852b3c3fdbf5510))
 
 ### Selectmenu
 
-* Fixed: Don't render options with the `hidden` attribute ([#15098](https://bugs.jqueryui.com/ticket/15098), [a2b25ef6c](https://github.com/jquery/jquery-ui/commit/a2b25ef6caae3e1a272214839b815a6387618124))
+* Fixed: Don't render options with the `hidden` attribute ([trac-15098](https://bugs.jqueryui.com/ticket/15098), [a2b25ef6c](https://github.com/jquery/jquery-ui/commit/a2b25ef6caae3e1a272214839b815a6387618124))
 
 ### Slider
 
-* Changed: Use `cursor: pointer` on handles ([#9371](https://bugs.jqueryui.com/ticket/9371), [c6e2b52d7](https://github.com/jquery/jquery-ui/commit/c6e2b52d70b8caf920f382402aba9f04de7e32b2))
+* Changed: Use `cursor: pointer` on handles ([trac-9371](https://bugs.jqueryui.com/ticket/9371), [c6e2b52d7](https://github.com/jquery/jquery-ui/commit/c6e2b52d70b8caf920f382402aba9f04de7e32b2))
 
 ### Spinner
 
-* Spinner: Ignore `mousewheel` events when not focused ([#15139](https://bugs.jqueryui.com/ticket/15139), [a3b9129be](https://github.com/jquery/jquery-ui/commit/a3b9129be19afabb3fa6b2fb913b85aab43f4652))
+* Spinner: Ignore `mousewheel` events when not focused ([trac-15139](https://bugs.jqueryui.com/ticket/15139), [a3b9129be](https://github.com/jquery/jquery-ui/commit/a3b9129be19afabb3fa6b2fb913b85aab43f4652))
 * Spinner: Fix typo ([863a49f95](https://github.com/jquery/jquery-ui/commit/863a49f95b181adaf76cbaf268e4ecf5485dbcf1))
 
 ### Tabs
 
-* Fixed: Don't blur focused tab on sort ([#14627](https://bugs.jqueryui.com/ticket/14627), [f1fa076f6](https://github.com/jquery/jquery-ui/commit/f1fa076f62e99089257f6f8159cb2ce503f0abc2))
-* Fixed: Remove presentation role ([#10122](https://bugs.jqueryui.com/ticket/10122), [b9ffc3471](https://github.com/jquery/jquery-ui/commit/b9ffc34710212fd910717ab735818ef265c9372e))
+* Fixed: Don't blur focused tab on sort ([trac-14627](https://bugs.jqueryui.com/ticket/14627), [f1fa076f6](https://github.com/jquery/jquery-ui/commit/f1fa076f62e99089257f6f8159cb2ce503f0abc2))
+* Fixed: Remove presentation role ([trac-10122](https://bugs.jqueryui.com/ticket/10122), [b9ffc3471](https://github.com/jquery/jquery-ui/commit/b9ffc34710212fd910717ab735818ef265c9372e))
 
 ### Tooltip
 
-* Fixed: Clear interval for delayed tracking tooltips on remove ([#15099](https://bugs.jqueryui.com/ticket/15099), [9a4c05715](https://github.com/jquery/jquery-ui/commit/9a4c0571577e20795c19796594747f0f8beb476a))
+* Fixed: Clear interval for delayed tracking tooltips on remove ([trac-15099](https://bugs.jqueryui.com/ticket/15099), [9a4c05715](https://github.com/jquery/jquery-ui/commit/9a4c0571577e20795c19796594747f0f8beb476a))
 
 ## Interactions
 
 ### Droppable
 
-* Fixed: Use `$.ui.intersect()` ([#14963](https://bugs.jqueryui.com/ticket/14963), [fd30534b7](https://github.com/jquery/jquery-ui/commit/fd30534b73eaf9c076f93a349dbe0c7a77efc209))
+* Fixed: Use `$.ui.intersect()` ([trac-14963](https://bugs.jqueryui.com/ticket/14963), [fd30534b7](https://github.com/jquery/jquery-ui/commit/fd30534b73eaf9c076f93a349dbe0c7a77efc209))
 
 ### Focusable
 
@@ -103,26 +103,26 @@ Released on September 3, 2021
 ### Position
 
 * Fixed: Make sure `of` is treated as a CSS selector ([effa323f1](https://github.com/jquery/jquery-ui/commit/effa323f1505f2ce7a324e4f429fa9032c72f280))
-* Fixed: Increase scrollbar test div to handle larger scrollbars ([#15106](https://bugs.jqueryui.com/ticket/15106), [efb1fee02](https://github.com/jquery/jquery-ui/commit/efb1fee02b53c8fc17c3ffe68162f51b583e75f0))
+* Fixed: Increase scrollbar test div to handle larger scrollbars ([trac-15106](https://bugs.jqueryui.com/ticket/15106), [efb1fee02](https://github.com/jquery/jquery-ui/commit/efb1fee02b53c8fc17c3ffe68162f51b583e75f0))
 
 ### Resizable
 
 * Fixed: CSP violation (style `unsafe-inline`) ([dadde722a](https://github.com/jquery/jquery-ui/commit/dadde722a40ee41bd721e7d4609ee190815055c2))
 * Fixed: Keep user-provided handles on destroy ([c426b9a20](https://github.com/jquery/jquery-ui/commit/c426b9a203271ab5e5e5f165a1d686c8281164bf))
-* Fixed: Keep user defined handles on `_setOption` ([#15084](https://bugs.jqueryui.com/ticket/15084), [278d1e110](https://github.com/jquery/jquery-ui/commit/278d1e1108e6c12d35be9edce2a9efcab1946229))
-* Fixed: `aspectRatio` cannot be changed after initialization. ([#4186](https://bugs.jqueryui.com/ticket/4186), [c481400f2](https://github.com/jquery/jquery-ui/commit/c481400f222c871ba5853bc2930a3b8b4375d08b))
+* Fixed: Keep user defined handles on `_setOption` ([trac-15084](https://bugs.jqueryui.com/ticket/15084), [278d1e110](https://github.com/jquery/jquery-ui/commit/278d1e1108e6c12d35be9edce2a9efcab1946229))
+* Fixed: `aspectRatio` cannot be changed after initialization. ([trac-4186](https://bugs.jqueryui.com/ticket/4186), [c481400f2](https://github.com/jquery/jquery-ui/commit/c481400f222c871ba5853bc2930a3b8b4375d08b))
 
 ### Sortable
 
 * Sortable: Remove reference to .disableSelection() from demos ([d193d0ba8](https://github.com/jquery/jquery-ui/commit/d193d0ba8532206763b666bcc62665b357aef021))
-* Sortable: Fix various scrolling issues ([#3173](https://bugs.jqueryui.com/ticket/3173), [#15165](https://bugs.jqueryui.com/ticket/15165), [#15166](https://bugs.jqueryui.com/ticket/15166), [#15167](https://bugs.jqueryui.com/ticket/15167), [#15168](https://bugs.jqueryui.com/ticket/15168), [#15169](https://bugs.jqueryui.com/ticket/15169), [#15170](https://bugs.jqueryui.com/ticket/15170), [c866e4553](https://github.com/jquery/jquery-ui/commit/c866e455373028a62a0956455a229fef63e91fac))
-* Sortable: Fix `z-index` switching from `auto` to `0` ([#14683](https://bugs.jqueryui.com/ticket/14683), [9c5ce4c3e](https://github.com/jquery/jquery-ui/commit/9c5ce4c3e986136b8dce14b6b1ccd5296d932f01))
-* Sortable: Setting table row placeholder height to be same as sorted row ([#13662](https://bugs.jqueryui.com/ticket/13662), [87eab46a5](https://github.com/jquery/jquery-ui/commit/87eab46a589031d781299937f95f22bf61b5ef27))
-* Sortable: Fix parent offset detection ([#15021](https://bugs.jqueryui.com/ticket/15021), [1d409528a](https://github.com/jquery/jquery-ui/commit/1d409528a164c550e4e167c367f33ab3b7ad0e66))
+* Sortable: Fix various scrolling issues ([trac-3173](https://bugs.jqueryui.com/ticket/3173), [trac-15165](https://bugs.jqueryui.com/ticket/15165), [trac-15166](https://bugs.jqueryui.com/ticket/15166), [trac-15167](https://bugs.jqueryui.com/ticket/15167), [trac-15168](https://bugs.jqueryui.com/ticket/15168), [trac-15169](https://bugs.jqueryui.com/ticket/15169), [trac-15170](https://bugs.jqueryui.com/ticket/15170), [c866e4553](https://github.com/jquery/jquery-ui/commit/c866e455373028a62a0956455a229fef63e91fac))
+* Sortable: Fix `z-index` switching from `auto` to `0` ([trac-14683](https://bugs.jqueryui.com/ticket/14683), [9c5ce4c3e](https://github.com/jquery/jquery-ui/commit/9c5ce4c3e986136b8dce14b6b1ccd5296d932f01))
+* Sortable: Setting table row placeholder height to be same as sorted row ([trac-13662](https://bugs.jqueryui.com/ticket/13662), [87eab46a5](https://github.com/jquery/jquery-ui/commit/87eab46a589031d781299937f95f22bf61b5ef27))
+* Sortable: Fix parent offset detection ([trac-15021](https://bugs.jqueryui.com/ticket/15021), [1d409528a](https://github.com/jquery/jquery-ui/commit/1d409528a164c550e4e167c367f33ab3b7ad0e66))
 
 ## CSS
 
-* Removed: CSS for `ui-state-checked` as it's not used any more ([#15059](https://bugs.jqueryui.com/ticket/15059), [1b0e947f4](https://github.com/jquery/jquery-ui/commit/1b0e947f46bc1261b15816f2dcbd239d83a86335))
+* Removed: CSS for `ui-state-checked` as it's not used any more ([trac-15059](https://bugs.jqueryui.com/ticket/15059), [1b0e947f4](https://github.com/jquery/jquery-ui/commit/1b0e947f46bc1261b15816f2dcbd239d83a86335))
 * Fixed: Resolve csslint issues with the IE filter property ([b15e45a45](https://github.com/jquery/jquery-ui/commit/b15e45a45100ad8e64ef0d362380d9aa27fe6862))
 * Fixed: Don't load the image sprite for 'ui-icon-blank' ([43254468d](https://github.com/jquery/jquery-ui/commit/43254468de7d69b5422e667ba7ebbe864fc34a63))
 * Fixed: Replace missing definition for default icons ([dde9b83df](https://github.com/jquery/jquery-ui/commit/dde9b83df61d1d676e66cb2a2f7970dd44a05137))
@@ -135,6 +135,6 @@ Released on September 3, 2021
 * Changed: Update npm dependencies ([491ecc1bd](https://github.com/jquery/jquery-ui/commit/491ecc1bd5c48a24d8a4bcff6f74ca368b37fdf3), [91b6fc3f0](https://github.com/jquery/jquery-ui/commit/91b6fc3f08a6256ebb8006f96661db163aa8b5bc), [a22361dbe](https://github.com/jquery/jquery-ui/commit/a22361dbe491c494a87f38600d9c1f91aa07d3e0))
 * Changed: Don't publish `dist/cdn` to npm ([74af51279](https://github.com/jquery/jquery-ui/commit/74af51279419b2f901cfbacbbecd47136b3d7569))
 * Changed: Update dependencies passed to `jquery-release` ([399c81e07](https://github.com/jquery/jquery-ui/commit/399c81e077823f83faf18d9366e5a09d1c0734a2))
-* Changed: Migrate from JSHint & JSCS to ESLint ([#15393](https://bugs.jqueryui.com/ticket/15393), [70dae67b7](https://github.com/jquery/jquery-ui/commit/70dae67b73dfea9126f126f516fe8286f1e73417))
+* Changed: Migrate from JSHint & JSCS to ESLint ([trac-15393](https://bugs.jqueryui.com/ticket/15393), [70dae67b7](https://github.com/jquery/jquery-ui/commit/70dae67b73dfea9126f126f516fe8286f1e73417))
 * Changed: Rename the primary branch `master` to `main` ([19c628675](https://github.com/jquery/jquery-ui/commit/19c628675dadc714616af975969694267f3840df))
 * Changed: Rename `jquery-1-7` to `jquery-patch` ([7caf8f61d](https://github.com/jquery/jquery-ui/commit/7caf8f61df7840fb3de2478a75aec229d9f84f15))

--- a/page/changelog/1.13.0.md
+++ b/page/changelog/1.13.0.md
@@ -13,88 +13,88 @@ Released on October 7, 2021
 
 ### UI Core
 
-* Fixed: Rename from `.form()` to `._form()` since its not for public use ([#15074](https://bugs.jqueryui.com/ticket/15074), [0627eb364](https://github.com/jquery/jquery-ui/commit/0627eb3645009d868ae20a27d0a283acd5797a1f))
-* Fixed: Handle empty sets in Labels ([#15184](https://bugs.jqueryui.com/ticket/15184), [adcf9b6f6](https://github.com/jquery/jquery-ui/commit/adcf9b6f6ef9c6dfa88932b40307f581e65bc667))
-* Removed: `$.ui.escapeSelector` in favor of `$.escapeSelector` ([#14991](https://bugs.jqueryui.com/ticket/14991), [7c6a9f012](https://github.com/jquery/jquery-ui/commit/7c6a9f01281a9739f54ef57d7deecb41a873ef38))
+* Fixed: Rename from `.form()` to `._form()` since its not for public use ([trac-15074](https://bugs.jqueryui.com/ticket/15074), [0627eb364](https://github.com/jquery/jquery-ui/commit/0627eb3645009d868ae20a27d0a283acd5797a1f))
+* Fixed: Handle empty sets in Labels ([trac-15184](https://bugs.jqueryui.com/ticket/15184), [adcf9b6f6](https://github.com/jquery/jquery-ui/commit/adcf9b6f6ef9c6dfa88932b40307f581e65bc667))
+* Removed: `$.ui.escapeSelector` in favor of `$.escapeSelector` ([trac-14991](https://bugs.jqueryui.com/ticket/14991), [7c6a9f012](https://github.com/jquery/jquery-ui/commit/7c6a9f01281a9739f54ef57d7deecb41a873ef38))
 
 ### Widget Factory
 
 * Fixed: Boolean option when under use strict ([2434dfd45](https://github.com/jquery/jquery-ui/commit/2434dfd45d0805304e1db634d059feaa0bacf358))
-* Fixed: Handle `Object.create(null)` for options objects ([#15179](https://bugs.jqueryui.com/ticket/15179), [b3c0a7f71](https://github.com/jquery/jquery-ui/commit/b3c0a7f71d0b351755b97858ad47de4e9a373606))
-* Fixed: Improve `remove` event bindings for `classes` options ([#15078](https://bugs.jqueryui.com/ticket/15078), [#15082](https://bugs.jqueryui.com/ticket/15082), [#15095](https://bugs.jqueryui.com/ticket/15095), [#15136](https://bugs.jqueryui.com/ticket/15136), [#15152](https://bugs.jqueryui.com/ticket/15152), [ef2e9bab9](https://github.com/jquery/jquery-ui/commit/ef2e9bab92ae898311baa295590cd487d9071319))
+* Fixed: Handle `Object.create(null)` for options objects ([trac-15179](https://bugs.jqueryui.com/ticket/15179), [b3c0a7f71](https://github.com/jquery/jquery-ui/commit/b3c0a7f71d0b351755b97858ad47de4e9a373606))
+* Fixed: Improve `remove` event bindings for `classes` options ([trac-15078](https://bugs.jqueryui.com/ticket/15078), [trac-15082](https://bugs.jqueryui.com/ticket/15082), [trac-15095](https://bugs.jqueryui.com/ticket/15095), [trac-15136](https://bugs.jqueryui.com/ticket/15136), [trac-15152](https://bugs.jqueryui.com/ticket/15152), [ef2e9bab9](https://github.com/jquery/jquery-ui/commit/ef2e9bab92ae898311baa295590cd487d9071319))
 * Fixed: Don't swallow errors in `remove` events ([1f2011ece](https://github.com/jquery/jquery-ui/commit/1f2011ece3fe6847874677e9a8210fa202498ccb))
 
 ## Widgets
 
 ### Autocomplete
 
-* Fixed: IE/Edge scrolling issues ([#9638](https://bugs.jqueryui.com/ticket/9638), [573e7e69c](https://github.com/jquery/jquery-ui/commit/573e7e69c9b63752fb06a15d60ec2dded839e093))
-* Fixed: Escape HTML tags in callback name to avoid XSS in demo ([#15048](https://bugs.jqueryui.com/ticket/15048), [69e66ea65](https://github.com/jquery/jquery-ui/commit/69e66ea6556584c39621c184f8f790a1011408ce))
+* Fixed: IE/Edge scrolling issues ([trac-9638](https://bugs.jqueryui.com/ticket/9638), [573e7e69c](https://github.com/jquery/jquery-ui/commit/573e7e69c9b63752fb06a15d60ec2dded839e093))
+* Fixed: Escape HTML tags in callback name to avoid XSS in demo ([trac-15048](https://bugs.jqueryui.com/ticket/15048), [69e66ea65](https://github.com/jquery/jquery-ui/commit/69e66ea6556584c39621c184f8f790a1011408ce))
 
 ### Button
 
-* Fixed: Backcompat when called on collection of mixed elements ([#15109](https://bugs.jqueryui.com/ticket/15109), [abc9e7ce2](https://github.com/jquery/jquery-ui/commit/abc9e7ce2f3b60a18bf1f461c7cbfccb3fa02b53))
+* Fixed: Backcompat when called on collection of mixed elements ([trac-15109](https://bugs.jqueryui.com/ticket/15109), [abc9e7ce2](https://github.com/jquery/jquery-ui/commit/abc9e7ce2f3b60a18bf1f461c7cbfccb3fa02b53))
 
 ### Checkboxradio
 
-* Fixed: Don't add ui-state-hover to icons ([#15055](https://bugs.jqueryui.com/ticket/15055), [b9d687deb](https://github.com/jquery/jquery-ui/commit/b9d687deb58cce5f4c6e27dace9cb172e291698c))
+* Fixed: Don't add ui-state-hover to icons ([trac-15055](https://bugs.jqueryui.com/ticket/15055), [b9d687deb](https://github.com/jquery/jquery-ui/commit/b9d687deb58cce5f4c6e27dace9cb172e291698c))
 
 ### Datepicker
 
 * Added: Add option for `onUpdateDatepicker` callback ([17d115b82](https://github.com/jquery/jquery-ui/commit/17d115b8298b935ab0d26b881d4f6f3e83984868), [a12c98574](https://github.com/jquery/jquery-ui/commit/a12c98574d07f002fd59d166f9fc1fd391581b91))
 * Added: German localization ([ddbcc5d29](https://github.com/jquery/jquery-ui/commit/ddbcc5d29d069336ddaeab221db91220b95da175))
 * Fixed: Get `selectedDay` from `data-date` instead of element contents ([cf938e286](https://github.com/jquery/jquery-ui/commit/cf938e286382cc8f6cb74b3c6f75275073672aeb))
-* Fixed: Make sure text options are text, shorten HTML strings ([#15284](https://bugs.jqueryui.com/ticket/15284), [afe20b79a](https://github.com/jquery/jquery-ui/commit/afe20b79a64266e64011f34b26a30b3d1c62fd47))
-* Fixed: Make sure `altField` is treated as a CSS selector ([32850869d](https://github.com/jquery/jquery-ui/commit/32850869d308d5e7c9bf3e3b4d483ea886d373ce))
+* Fixed: Make sure text options are text, shorten HTML strings ([CVE-2021-41183](https://github.com/jquery/jquery-ui/security/advisories/GHSA-j7qv-pgf6-hvh4), [trac-15284](https://bugs.jqueryui.com/ticket/15284), [afe20b79a](https://github.com/jquery/jquery-ui/commit/afe20b79a64266e64011f34b26a30b3d1c62fd47))
+* Fixed: Make sure `altField` is treated as a CSS selector ([CVE-2021-41182](https://github.com/jquery/jquery-ui/security/advisories/GHSA-9gj3-hwp5-pmwc), [32850869d](https://github.com/jquery/jquery-ui/commit/32850869d308d5e7c9bf3e3b4d483ea886d373ce))
 * Fixed: Hungarian localization to use uppercase for first characters ([9bb366ef8](https://github.com/jquery/jquery-ui/commit/9bb366ef8a710c06df924b2f6567cd5ed701cd44))
 * Fixed: Current instance memory leak and added unit testcases ([817ce3855](https://github.com/jquery/jquery-ui/commit/817ce38555f07981f929fb4b1229fc42574cf85c))
 * Fixed: Typo in `currentText` in `da` localization ([9c0d83f2e](https://github.com/jquery/jquery-ui/commit/9c0d83f2e55f6b33e650f8dcd6b53866601695fd))
-* Fixed: First day of week for `pt-PT` locale ([#15195](https://bugs.jqueryui.com/ticket/15195), [6fdd0e34a](https://github.com/jquery/jquery-ui/commit/6fdd0e34a74789d2da214739ea0f5a8feff71d7e))
-* Fixed: Swedish localization ([#15142](https://bugs.jqueryui.com/ticket/15142), [032ddc334](https://github.com/jquery/jquery-ui/commit/032ddc3349f625e0840aa8e266b5d8ebee994853))
-* Fixed: Prev/next button behavior with `showCurrentAtPos` ([#15102](https://bugs.jqueryui.com/ticket/15102), [17404ced4](https://github.com/jquery/jquery-ui/commit/17404ced478a235651513fa7bef3473ef1b039e8))
-* Fixed: Traditional Chinese translation ([#15060](https://bugs.jqueryui.com/ticket/15060), [129434384](https://github.com/jquery/jquery-ui/commit/12943438478e71db02e861b02cd406429fc3b080))
+* Fixed: First day of week for `pt-PT` locale ([trac-15195](https://bugs.jqueryui.com/ticket/15195), [6fdd0e34a](https://github.com/jquery/jquery-ui/commit/6fdd0e34a74789d2da214739ea0f5a8feff71d7e))
+* Fixed: Swedish localization ([trac-15142](https://bugs.jqueryui.com/ticket/15142), [032ddc334](https://github.com/jquery/jquery-ui/commit/032ddc3349f625e0840aa8e266b5d8ebee994853))
+* Fixed: Prev/next button behavior with `showCurrentAtPos` ([trac-15102](https://bugs.jqueryui.com/ticket/15102), [17404ced4](https://github.com/jquery/jquery-ui/commit/17404ced478a235651513fa7bef3473ef1b039e8))
+* Fixed: Traditional Chinese translation ([trac-15060](https://bugs.jqueryui.com/ticket/15060), [129434384](https://github.com/jquery/jquery-ui/commit/12943438478e71db02e861b02cd406429fc3b080))
 * Fixed: Adapt `datepicker.js` for a11y ([b864cd103](https://github.com/jquery/jquery-ui/commit/b864cd103a0acb76b0a34fb1dd382dc0925ef9a8))
 
 ### Dialog
 
 * Fixed: Broken focus re-triggering in jQuery 3.4/3.5 ([834ee5f7c](https://github.com/jquery/jquery-ui/commit/834ee5f7cfb621b5f75292915a00319927a9a6d0))
-* Fixed: Shared event handler for modal dialogs ([#15182](https://bugs.jqueryui.com/ticket/15182), [5708046ea](https://github.com/jquery/jquery-ui/commit/5708046ea1ba4d6d86f431ec9fd32d28ae7542f6))
+* Fixed: Shared event handler for modal dialogs ([trac-15182](https://bugs.jqueryui.com/ticket/15182), [5708046ea](https://github.com/jquery/jquery-ui/commit/5708046ea1ba4d6d86f431ec9fd32d28ae7542f6))
 
 ### Menu
 
 * Fixed: Account for scrollbars in jQuery 3.2 ([1712b9bbb](https://github.com/jquery/jquery-ui/commit/1712b9bbb2e214819508b00d8f318713e27cd949))
-* Fixed: Ignore mouse events triggered due to page scrolling ([#9356](https://bugs.jqueryui.com/ticket/9356), [50efd6e1b](https://github.com/jquery/jquery-ui/commit/50efd6e1b063822c4a0ecb38f324ed3354f387c4))
-* Fixed: Handle mouse movement mixed with keyboard navigation ([#9357](https://bugs.jqueryui.com/ticket/9357), [7d992ae29](https://github.com/jquery/jquery-ui/commit/7d992ae29d27cdab8787691a14e689e60c74c05c))
-* Fixed: Don't focus dividers when wrapping via keyboard navigation ([#15157](https://bugs.jqueryui.com/ticket/15157), [a3e953b49](https://github.com/jquery/jquery-ui/commit/a3e953b495905d0c67790e65032841451b470ce1))
-* Fixed: Close menus immediately on selection or click outside ([#15034](https://bugs.jqueryui.com/ticket/15034), [0d25a36ee](https://github.com/jquery/jquery-ui/commit/0d25a36eecb9e5598596208e4852b3c3fdbf5510))
+* Fixed: Ignore mouse events triggered due to page scrolling ([trac-9356](https://bugs.jqueryui.com/ticket/9356), [50efd6e1b](https://github.com/jquery/jquery-ui/commit/50efd6e1b063822c4a0ecb38f324ed3354f387c4))
+* Fixed: Handle mouse movement mixed with keyboard navigation ([trac-9357](https://bugs.jqueryui.com/ticket/9357), [7d992ae29](https://github.com/jquery/jquery-ui/commit/7d992ae29d27cdab8787691a14e689e60c74c05c))
+* Fixed: Don't focus dividers when wrapping via keyboard navigation ([trac-15157](https://bugs.jqueryui.com/ticket/15157), [a3e953b49](https://github.com/jquery/jquery-ui/commit/a3e953b495905d0c67790e65032841451b470ce1))
+* Fixed: Close menus immediately on selection or click outside ([trac-15034](https://bugs.jqueryui.com/ticket/15034), [0d25a36ee](https://github.com/jquery/jquery-ui/commit/0d25a36eecb9e5598596208e4852b3c3fdbf5510))
 
 ### Selectmenu
 
-* Fixed: Don't render options with the `hidden` attribute ([#15098](https://bugs.jqueryui.com/ticket/15098), [a2b25ef6c](https://github.com/jquery/jquery-ui/commit/a2b25ef6caae3e1a272214839b815a6387618124))
+* Fixed: Don't render options with the `hidden` attribute ([trac-15098](https://bugs.jqueryui.com/ticket/15098), [a2b25ef6c](https://github.com/jquery/jquery-ui/commit/a2b25ef6caae3e1a272214839b815a6387618124))
 
 ### Slider
 
-* Changed: Use `cursor: pointer` on handles ([#9371](https://bugs.jqueryui.com/ticket/9371), [c6e2b52d7](https://github.com/jquery/jquery-ui/commit/c6e2b52d70b8caf920f382402aba9f04de7e32b2))
+* Changed: Use `cursor: pointer` on handles ([trac-9371](https://bugs.jqueryui.com/ticket/9371), [c6e2b52d7](https://github.com/jquery/jquery-ui/commit/c6e2b52d70b8caf920f382402aba9f04de7e32b2))
 
 ### Spinner
 
-* Spinner: Ignore `mousewheel` events when not focused ([#15139](https://bugs.jqueryui.com/ticket/15139), [a3b9129be](https://github.com/jquery/jquery-ui/commit/a3b9129be19afabb3fa6b2fb913b85aab43f4652))
+* Spinner: Ignore `mousewheel` events when not focused ([trac-15139](https://bugs.jqueryui.com/ticket/15139), [a3b9129be](https://github.com/jquery/jquery-ui/commit/a3b9129be19afabb3fa6b2fb913b85aab43f4652))
 * Spinner: Fix typo ([863a49f95](https://github.com/jquery/jquery-ui/commit/863a49f95b181adaf76cbaf268e4ecf5485dbcf1))
 
 ### Tabs
 
-* Fixed: Don't blur focused tab on sort ([#14627](https://bugs.jqueryui.com/ticket/14627), [f1fa076f6](https://github.com/jquery/jquery-ui/commit/f1fa076f62e99089257f6f8159cb2ce503f0abc2))
-* Fixed: Remove presentation role ([#10122](https://bugs.jqueryui.com/ticket/10122), [b9ffc3471](https://github.com/jquery/jquery-ui/commit/b9ffc34710212fd910717ab735818ef265c9372e))
+* Fixed: Don't blur focused tab on sort ([trac-14627](https://bugs.jqueryui.com/ticket/14627), [f1fa076f6](https://github.com/jquery/jquery-ui/commit/f1fa076f62e99089257f6f8159cb2ce503f0abc2))
+* Fixed: Remove presentation role ([trac-10122](https://bugs.jqueryui.com/ticket/10122), [b9ffc3471](https://github.com/jquery/jquery-ui/commit/b9ffc34710212fd910717ab735818ef265c9372e))
 
 ### Tooltip
 
-* Fixed: Clear interval for delayed tracking tooltips on remove ([#15099](https://bugs.jqueryui.com/ticket/15099), [9a4c05715](https://github.com/jquery/jquery-ui/commit/9a4c0571577e20795c19796594747f0f8beb476a))
+* Fixed: Clear interval for delayed tracking tooltips on remove ([trac-15099](https://bugs.jqueryui.com/ticket/15099), [9a4c05715](https://github.com/jquery/jquery-ui/commit/9a4c0571577e20795c19796594747f0f8beb476a))
 
 ## Interactions
 
 ### Droppable
 
-* Fixed: Use `$.ui.intersect()` ([#14963](https://bugs.jqueryui.com/ticket/14963), [fd30534b7](https://github.com/jquery/jquery-ui/commit/fd30534b73eaf9c076f93a349dbe0c7a77efc209))
+* Fixed: Use `$.ui.intersect()` ([trac-14963](https://bugs.jqueryui.com/ticket/14963), [fd30534b7](https://github.com/jquery/jquery-ui/commit/fd30534b73eaf9c076f93a349dbe0c7a77efc209))
 
 ### Focusable
 
@@ -102,23 +102,23 @@ Released on October 7, 2021
 
 ### Position
 
-* Fixed: Make sure `of` is treated as a CSS selector ([effa323f1](https://github.com/jquery/jquery-ui/commit/effa323f1505f2ce7a324e4f429fa9032c72f280))
-* Fixed: Increase scrollbar test div to handle larger scrollbars ([#15106](https://bugs.jqueryui.com/ticket/15106), [efb1fee02](https://github.com/jquery/jquery-ui/commit/efb1fee02b53c8fc17c3ffe68162f51b583e75f0))
+* Fixed: Make sure `of` is treated as a CSS selector ([CVE-2021-41184](https://github.com/jquery/jquery-ui/security/advisories/GHSA-gpqq-952q-5327), [effa323f1](https://github.com/jquery/jquery-ui/commit/effa323f1505f2ce7a324e4f429fa9032c72f280))
+* Fixed: Increase scrollbar test div to handle larger scrollbars ([trac-15106](https://bugs.jqueryui.com/ticket/15106), [efb1fee02](https://github.com/jquery/jquery-ui/commit/efb1fee02b53c8fc17c3ffe68162f51b583e75f0))
 
 ### Resizable
 
 * Fixed: CSP violation (style `unsafe-inline`) ([dadde722a](https://github.com/jquery/jquery-ui/commit/dadde722a40ee41bd721e7d4609ee190815055c2))
 * Fixed: Keep user-provided handles on destroy ([c426b9a20](https://github.com/jquery/jquery-ui/commit/c426b9a203271ab5e5e5f165a1d686c8281164bf))
-* Fixed: Keep user defined handles on `_setOption` ([#15084](https://bugs.jqueryui.com/ticket/15084), [278d1e110](https://github.com/jquery/jquery-ui/commit/278d1e1108e6c12d35be9edce2a9efcab1946229))
-* Fixed: `aspectRatio` cannot be changed after initialization. ([#4186](https://bugs.jqueryui.com/ticket/4186), [c481400f2](https://github.com/jquery/jquery-ui/commit/c481400f222c871ba5853bc2930a3b8b4375d08b))
+* Fixed: Keep user defined handles on `_setOption` ([trac-15084](https://bugs.jqueryui.com/ticket/15084), [278d1e110](https://github.com/jquery/jquery-ui/commit/278d1e1108e6c12d35be9edce2a9efcab1946229))
+* Fixed: `aspectRatio` cannot be changed after initialization. ([trac-4186](https://bugs.jqueryui.com/ticket/4186), [c481400f2](https://github.com/jquery/jquery-ui/commit/c481400f222c871ba5853bc2930a3b8b4375d08b))
 
 ### Sortable
 
 * Sortable: Remove reference to .disableSelection() from demos ([d193d0ba8](https://github.com/jquery/jquery-ui/commit/d193d0ba8532206763b666bcc62665b357aef021))
-* Sortable: Fix various scrolling issues ([#3173](https://bugs.jqueryui.com/ticket/3173), [#15165](https://bugs.jqueryui.com/ticket/15165), [#15166](https://bugs.jqueryui.com/ticket/15166), [#15167](https://bugs.jqueryui.com/ticket/15167), [#15168](https://bugs.jqueryui.com/ticket/15168), [#15169](https://bugs.jqueryui.com/ticket/15169), [#15170](https://bugs.jqueryui.com/ticket/15170), [c866e4553](https://github.com/jquery/jquery-ui/commit/c866e455373028a62a0956455a229fef63e91fac))
-* Sortable: Fix `z-index` switching from `auto` to `0` ([#14683](https://bugs.jqueryui.com/ticket/14683), [9c5ce4c3e](https://github.com/jquery/jquery-ui/commit/9c5ce4c3e986136b8dce14b6b1ccd5296d932f01))
-* Sortable: Setting table row placeholder height to be same as sorted row ([#13662](https://bugs.jqueryui.com/ticket/13662), [87eab46a5](https://github.com/jquery/jquery-ui/commit/87eab46a589031d781299937f95f22bf61b5ef27))
-* Sortable: Fix parent offset detection ([#15021](https://bugs.jqueryui.com/ticket/15021), [1d409528a](https://github.com/jquery/jquery-ui/commit/1d409528a164c550e4e167c367f33ab3b7ad0e66))
+* Sortable: Fix various scrolling issues ([trac-3173](https://bugs.jqueryui.com/ticket/3173), [trac-15165](https://bugs.jqueryui.com/ticket/15165), [trac-15166](https://bugs.jqueryui.com/ticket/15166), [trac-15167](https://bugs.jqueryui.com/ticket/15167), [trac-15168](https://bugs.jqueryui.com/ticket/15168), [trac-15169](https://bugs.jqueryui.com/ticket/15169), [trac-15170](https://bugs.jqueryui.com/ticket/15170), [c866e4553](https://github.com/jquery/jquery-ui/commit/c866e455373028a62a0956455a229fef63e91fac))
+* Sortable: Fix `z-index` switching from `auto` to `0` ([trac-14683](https://bugs.jqueryui.com/ticket/14683), [9c5ce4c3e](https://github.com/jquery/jquery-ui/commit/9c5ce4c3e986136b8dce14b6b1ccd5296d932f01))
+* Sortable: Setting table row placeholder height to be same as sorted row ([trac-13662](https://bugs.jqueryui.com/ticket/13662), [87eab46a5](https://github.com/jquery/jquery-ui/commit/87eab46a589031d781299937f95f22bf61b5ef27))
+* Sortable: Fix parent offset detection ([trac-15021](https://bugs.jqueryui.com/ticket/15021), [1d409528a](https://github.com/jquery/jquery-ui/commit/1d409528a164c550e4e167c367f33ab3b7ad0e66))
 
 ## CSS
 
@@ -132,7 +132,7 @@ Released on October 7, 2021
 * Changed: Update npm dependencies ([491ecc1bd](https://github.com/jquery/jquery-ui/commit/491ecc1bd5c48a24d8a4bcff6f74ca368b37fdf3), [91b6fc3f0](https://github.com/jquery/jquery-ui/commit/91b6fc3f08a6256ebb8006f96661db163aa8b5bc), [a22361dbe](https://github.com/jquery/jquery-ui/commit/a22361dbe491c494a87f38600d9c1f91aa07d3e0))
 * Changed: Don't publish `dist/cdn` to npm ([74af51279](https://github.com/jquery/jquery-ui/commit/74af51279419b2f901cfbacbbecd47136b3d7569))
 * Changed: Update dependencies passed to `jquery-release` ([399c81e07](https://github.com/jquery/jquery-ui/commit/399c81e077823f83faf18d9366e5a09d1c0734a2))
-* Changed: Migrate from JSHint & JSCS to ESLint ([#15393](https://bugs.jqueryui.com/ticket/15393), [70dae67b7](https://github.com/jquery/jquery-ui/commit/70dae67b73dfea9126f126f516fe8286f1e73417))
+* Changed: Migrate from JSHint & JSCS to ESLint ([trac-15393](https://bugs.jqueryui.com/ticket/15393), [70dae67b7](https://github.com/jquery/jquery-ui/commit/70dae67b73dfea9126f126f516fe8286f1e73417))
 * Changed: Rename the primary branch `master` to `main` ([19c628675](https://github.com/jquery/jquery-ui/commit/19c628675dadc714616af975969694267f3840df))
 * Changed: Rename `jquery-1-7` to `jquery-patch` ([7caf8f61d](https://github.com/jquery/jquery-ui/commit/7caf8f61df7840fb3de2478a75aec229d9f84f15))
 * Changed: Require jQuery `>=1.8.0 <4.0.0`, not `>=1.6` in bower.json ([b0ed787d1](https://github.com/jquery/jquery-ui/commit/b0ed787d18e606afd81f941065ba35f291ffb245))

--- a/page/upgrade-guide/1.13.md
+++ b/page/upgrade-guide/1.13.md
@@ -24,6 +24,16 @@ jQuery UI 1.12 introduced API redesigns for Button, Buttonset, Dialog, Draggable
 
 The main focus of this release was improving compatibility with recent jQuery versions. Removal of deprecated APIs and removal of legacy browser support are not included. Therefore, the number of breaking changes is extremely limited compared to previous upgrades.
 
+### Security fixes
+
+A few security fixes have landed in this release; they're marked with their assigned CVEs below.
+
+### Strict mode
+
+Both the compiled jQuery UI JavaScript files and all individual AMD modules now use ECMAScript 5 strict mode. This shouldn't be noticeable to most users; some older debugging tools may not be able to step through the code, though.
+
+A similar change has been live in jQuery since version 3.0.0, so we're optimistic this will not cause issues for jQuery UI either.
+
 ### Files & directory structure
 
 There have been some minor changes to source files:
@@ -71,14 +81,14 @@ $( ".selector" ).accordion( {
 
 ### `altField` no longer accepts HTML input
 
-([gh-1954](https://github.com/jquery/jquery-ui/pull/1954), [3285086](https://github.com/jquery/jquery-ui/commit/32850869d308d5e7c9bf3e3b4d483ea886d373ce)) Due to a bug, the [`altField` option](https://api.jqueryui.com/datepicker/#option-altField) used to accept HTML input that created fresh elements. This is now fixed and all string input is treated as a CSS selector.
+([CVE-2021-41182](https://github.com/jquery/jquery-ui/security/advisories/GHSA-9gj3-hwp5-pmwc), [gh-1954](https://github.com/jquery/jquery-ui/pull/1954), [3285086](https://github.com/jquery/jquery-ui/commit/32850869d308d5e7c9bf3e3b4d483ea886d373ce)) Due to a bug, the [`altField` option](https://api.jqueryui.com/datepicker/#option-altField) used to accept HTML input that created fresh elements. This is now fixed and all string input is treated as a CSS selector.
 
 ### Various `*Text` options no longer accept HTML input
 
-([trac-15284](https://bugs.jqueryui.com/ticket/15284), [gh-1953](https://github.com/jquery/jquery-ui/pull/1953), [afe20b7](https://github.com/jquery/jquery-ui/commit/afe20b79a64266e64011f34b26a30b3d1c62fd47)) Various [Datepicker](https://api.jqueryui.com/datepicker/) `*Text` options: [`appendText`](https://api.jqueryui.com/datepicker/#option-appendText), [`buttonText`](https://api.jqueryui.com/datepicker/#option-buttonText), [`closeText`](https://api.jqueryui.com/datepicker/#option-closeText), [`currentText`](https://api.jqueryui.com/datepicker/#option-currentText), [`nextText`](https://api.jqueryui.com/datepicker/#option-nextText) and [`prevText`](https://api.jqueryui.com/datepicker/#option-prevText) used to erroneously accept HTML input despite never documented to do so. That disconnect between docs & reality can lead to security issues so the options now only accept text input.
+([CVE-2021-41183](https://github.com/jquery/jquery-ui/security/advisories/GHSA-j7qv-pgf6-hvh4), [trac-15284](https://bugs.jqueryui.com/ticket/15284), [gh-1953](https://github.com/jquery/jquery-ui/pull/1953), [afe20b7](https://github.com/jquery/jquery-ui/commit/afe20b79a64266e64011f34b26a30b3d1c62fd47)) Various [Datepicker](https://api.jqueryui.com/datepicker/) `*Text` options: [`appendText`](https://api.jqueryui.com/datepicker/#option-appendText), [`buttonText`](https://api.jqueryui.com/datepicker/#option-buttonText), [`closeText`](https://api.jqueryui.com/datepicker/#option-closeText), [`currentText`](https://api.jqueryui.com/datepicker/#option-currentText), [`nextText`](https://api.jqueryui.com/datepicker/#option-nextText) and [`prevText`](https://api.jqueryui.com/datepicker/#option-prevText) used to erroneously accept HTML input despite never documented to do so. That disconnect between docs & reality can lead to security issues so the options now only accept text input.
 
 ## Position
 
 ### `of` is treated as a CSS selector
 
-([gh-1955](https://github.com/jquery/jquery-ui/pull/1955), [effa323](https://github.com/jquery/jquery-ui/commit/effa323f1505f2ce7a324e4f429fa9032c72f280)) Due to a bug, the [`of` option](https://api.jqueryui.com/position/#position-options-options) used to accept HTML input that created fresh elements. This is now fixed and all string input is treated as a CSS selector.
+([CVE-2021-41184](https://github.com/jquery/jquery-ui/security/advisories/GHSA-gpqq-952q-5327), [gh-1955](https://github.com/jquery/jquery-ui/pull/1955), [effa323](https://github.com/jquery/jquery-ui/commit/effa323f1505f2ce7a324e4f429fa9032c72f280)) Due to a bug, the [`of` option](https://api.jqueryui.com/position/#position-options-options) used to accept HTML input that created fresh elements. This is now fixed and all string input is treated as a CSS selector.


### PR DESCRIPTION
Summary of the changes:
* Change references to Trac issues from `#NUMBER` to `trac-NUMBER`; we're going
to use GitHub from now on so this should reduce the confusion
* Add info about 1.13 CVEs to changelogs & the upgrade guide, next to each
relevant change
* Add info about security fixes & using strict mode to the 1.13 upgrade guide