### PR TITLE
All: Upgrade the docs for latest UI 1.13 & upcoming 1.14 changes

### DIFF
--- a/page/index.html
+++ b/page/index.html
@@ -67,11 +67,14 @@
 
 <h2>What's New in jQuery UI 1.13?</h2>
 
-<p><strong>Compatibility with recent jQuery versions (up to 3.6)</strong>: Usage of deprecated jQuery APIs have been removed. jQuery UI 1.13 triggers no jQuery Migrate warnings when running its test suite against jQuery 3.6.0 with jQuery Migrate 3.3.2, i.e. the latest versions at the moment of its release.</p>
+<p><strong>Compatibility with recent jQuery versions (up to 3.7)</strong>: Usage of deprecated jQuery APIs have been removed. jQuery UI 1.13.3 triggers no jQuery Migrate warnings when running its test suite against jQuery 3.7.1 with jQuery Migrate 3.4.1, i.e. the latest versions at the moment of its release.</p>
 
 <p>Interested in the full details of what changed? Check out the
-<a href="/upgrade-guide/1.13/">1.13 upgrade guide</a>, and
-<a href="/changelog/1.13.0/">1.13.0 changelog</a>.</p>
+<a href="/upgrade-guide/1.13/">1.13 upgrade guide</a>,
+<a href="/changelog/1.13.0/">1.13.0 changelog</a>,
+<a href="/changelog/1.13.1/">1.13.1 changelog</a>,
+<a href="/changelog/1.13.2/">1.13.2 changelog</a>, and
+<a href="/changelog/1.13.3/">1.13.3 changelog</a>.</p>
 
 <hr class="dots">
 <h2>Dive In!</h2>

--- a/page/upgrade-guide/1.12.md
+++ b/page/upgrade-guide/1.12.md
@@ -18,9 +18,9 @@ jQuery UI 1.12 introduces API redesigns for Button, Buttonset, Dialog, Draggable
 <script src="jquery-ui.js"></script>
 ```
 
-### Preparing for jQuery UI 1.14
+### Preparing for a future jQuery UI release
 
-The API redesigns deprecate some functionality, which will be removed in 1.14. You don't have to wait for the 1.14.0 release in order to find out if your code will work when the 1.11 APIs are removed. You can use the `$.uiBackCompat` flag to test this with any 1.12 release.
+The API redesigns deprecate some functionality, which will be removed in the future. You don't have to wait in order to find out if your code will work when the 1.11 APIs are removed. You can use the `$.uiBackCompat` flag to test this with any 1.12 release.
 
 <p class="note">If you find a regression from the 1.11 API, please report it in the <a href="https://bugs.jqueryui.com/newticket">bug tracker</a>. Even though the 1.11 API is deprecated, it's important for 1.12 releases not to regress so that users are encouraged to upgrade even if they're not ready to use the new APIs. Note that
 most 1.10 APIs which were deprecated in 1.11 were removed in 1.12 and will not exist, regardless of the <code>$.uiBackCompat</code> flag.</p>

--- a/page/upgrade-guide/1.13.md
+++ b/page/upgrade-guide/1.13.md
@@ -10,7 +10,7 @@ This guide will assist in upgrading from jQuery UI 1.12.x to jQuery UI 1.13.x. A
 ## Reminder: API Redesigns
 
 jQuery UI 1.12 introduced API redesigns for Button, Buttonset, Dialog, Draggable, Droppable, Menu, Mouse, Resizable, Selectable, Sortable, Tabs, Tooltip, and Effects. You can read about the API redesign process on the
-[jQuery UI Blog](https://blog.jqueryui.com/2011/03/api-redesigns-the-past-present-and-future/). Although the redesigns introduced breaking changes, **1.12 & 1.13 maintains a lot of compatibility with the 1.11 API by default.** This is accomplished by rebuilding the 1.11 API on top of the 1.12/1.13 API. The default behavior for all 1.12 & 1.13 releases will be to simultaneously use the 1.11 and 1.12/1.13 APIs where possible. If you would like to load just the 1.12/1.13 API without the 1.11 API to prepare for jQuery UI 1.14, you can set the `$.uiBackCompat` flag to `false`.
+[jQuery UI Blog](https://blog.jqueryui.com/2011/03/api-redesigns-the-past-present-and-future/). Although the redesigns introduced breaking changes, **1.12 & 1.13 maintains a lot of compatibility with the 1.11 API by default.** This is accomplished by rebuilding the 1.11 API on top of the 1.12/1.13 API. The default behavior for all 1.12 & 1.13 releases will be to simultaneously use the 1.11 and 1.12/1.13 APIs where possible. If you would like to load just the 1.12/1.13 API without the 1.11 API to prepare for removal of these legacy APIs, you can set the `$.uiBackCompat` flag to `false`.
 
 ```html
 <script src="jquery.js"></script>


### PR DESCRIPTION
Changes:
1. Properly reflect testing against newer jQuery Core on the home page.
2. Update 1.12 & 1.13 upgrade guides to no longer claim 1.11 compatibility will be completely dropped in 1.14. Mention a future jQuery UI release instead as we don't want to commit to a specific version at this point.