### PR TITLE
Build: Fix copying top-level demos files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,14 +129,18 @@ grunt.registerTask( "build-demos", function() {
 
 	// Copy all demos files to /resources/demos
 	grunt.file.recurse( demosDir, function( abspath, rootdir, subdir, filename ) {
+		if ( filename.startsWith( "." ) ) {
+			return;
+		}
+
 		if ( filename === "index.html" ) {
 			return;
 		}
 
 		var content, $,
-			destDir = targetDir + "/" + subdir + "/",
+			destDir = `${ targetDir }${ subdir ? `/${ subdir }` : "" }/`,
 			dest = destDir + filename,
-			highlightDest = highlightDir + "/" + subdir + "/" + filename;
+			highlightDest = `${ highlightDir }${ subdir ? `/${ subdir }` : "" }/${ filename }`;
 
 		if ( /html$/.test( filename ) ) {
 			content = replaceResources( grunt.file.read( abspath ) );

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,7 +105,7 @@ grunt.registerTask( "build-demos", function() {
 		return a.title.toLowerCase() > b.title.toLowerCase() ? 1 : -1;
 	}
 
-	var demosDir, externalDir, jqueryCore, repoDir, pkg, subdir,
+	var demosDir, jqueryCore, repoDir, pkg, subdir,
 		path = require( "path" ),
 		cheerio = require( "cheerio" ),
 		targetDir = grunt.config( "wordpress.dir" ) + "/resources/demos",
@@ -123,7 +123,6 @@ grunt.registerTask( "build-demos", function() {
 	repoDir = path.resolve( repoDir );
 
 	demosDir = path.join( repoDir, "demos" );
-	externalDir = path.join( repoDir, "external" ).replace( process.cwd() + "/", "" );
 	pkg = require( path.join( repoDir, "package" ) );
 	jqueryCore = fs.readFileSync( path.join( repoDir, "external/jquery/jquery.js" ) )
 		.toString().match( /jQuery JavaScript Library v([0-9.]*)/ )[ 1 ];
@@ -180,7 +179,7 @@ grunt.registerTask( "build-demos", function() {
 	grunt.file.write( targetDir + "/demo-list.json", JSON.stringify( demoList, null, "\t" ) );
 
 	function deAmd( $, destDir ) {
-		var i18n, globalize,
+		var i18n, external,
 			bootstrap = $( "script[src='../bootstrap.js']" ),
 			require = $( "script[src='../../external/requirejs/require.js']" ),
 			extra = bootstrap.attr( "data-modules" );


### PR DESCRIPTION
The logic to copy files from demos was faulty for top-level files - it was
copying them to the `undefined` subdirectory. This is now fixed.

Also, dot-files are no longer copied; we don't need the ESLint config copied,
for example.

Also, the first commit contains some minor cleanup:
1. Remove the `externalDir` variable that was computed but not used.
2. Remove the local unused `globalize` variable.
3. Declare the local `external` variable - previously, build code was
   overwriting the `external` global.